### PR TITLE
Add method defaults to IMixinConfigPlugin

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/extensibility/IMixinConfigPlugin.java
+++ b/src/main/java/org/spongepowered/asm/mixin/extensibility/IMixinConfigPlugin.java
@@ -88,7 +88,7 @@ public interface IMixinConfigPlugin {
      * @param otherTargets Target class set incorporating targets from all other
      *      configs, read-only
      */
-    public abstract void acceptTargets(Set<String> myTargets, Set<String> otherTargets);
+    public default void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
     
     /**
      * After mixins specified in the configuration have been processed, this

--- a/src/main/java/org/spongepowered/asm/mixin/extensibility/IMixinConfigPlugin.java
+++ b/src/main/java/org/spongepowered/asm/mixin/extensibility/IMixinConfigPlugin.java
@@ -61,7 +61,7 @@ public interface IMixinConfigPlugin {
      * 
      * @return Path to the refmap resource or null to revert to the default
      */
-    public abstract String getRefMapperConfig();
+    public default String getRefMapperConfig() { return null; }
     
     /**
      * Called during mixin intialisation, allows this plugin to control whether
@@ -98,7 +98,7 @@ public interface IMixinConfigPlugin {
      * 
      * @return additional mixins to apply
      */
-    public abstract List<String> getMixins();
+    public default List<String> getMixins() { return null; }
 
     /**
      * Called immediately <b>before</b> a mixin is applied to a target class,
@@ -109,7 +109,7 @@ public interface IMixinConfigPlugin {
      * @param mixinClassName Name of the mixin class
      * @param mixinInfo Information about this mixin
      */
-    public abstract void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo);
+    public default void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
 
     /**
      * Called immediately <b>after</b> a mixin is applied to a target class,
@@ -120,5 +120,5 @@ public interface IMixinConfigPlugin {
      * @param mixinClassName Name of the mixin class
      * @param mixinInfo Information about this mixin
      */
-    public abstract void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo);
+    public default void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
 }


### PR DESCRIPTION
Defaults for `getRefMapperConfig`, `acceptTargets`, `getMixins`, `preApply`, and `postApply`

Remaining abstract methods are `onLoad` and `shouldApplyMixin`. I have considered making `shouldApplyMixin` default to `true` but I feel this needs further discussion as to the semantics - should it attempt to verify the arguments by default?