### PR TITLE
Changing minVersion missing warning into debug

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
@@ -406,6 +406,10 @@ final class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
     }
 
     private boolean checkVersion() throws MixinInitialisationError {
+        if (this.version == null) {
+            this.logger.debug("Mixin config {} does not specify \"minVersion\" property", this.name);
+        }
+        
         VersionNumber minVersion = VersionNumber.parse(this.version);
         VersionNumber curVersion = VersionNumber.parse(this.env.getVersion());
         if (minVersion.compareTo(curVersion) > 0) {

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
@@ -406,10 +406,6 @@ final class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
     }
 
     private boolean checkVersion() throws MixinInitialisationError {
-        if (this.version == null) {
-            this.logger.warn("Mixin config {} does not specify \"minVersion\" property", this.name);
-        }
-        
         VersionNumber minVersion = VersionNumber.parse(this.version);
         VersionNumber curVersion = VersionNumber.parse(this.env.getVersion());
         if (minVersion.compareTo(curVersion) > 0) {


### PR DESCRIPTION
Well, I don't know if this is how you remove the warning but here it is.

Every time you launch Minecraft, almost every single mixin will print this warning because this `minVersion` is not applied by Loom for whatever reason and no modders care about adding the field themselves.