### PR TITLE
Allow the modid to be pass through

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/Mixins.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Mixins.java
@@ -96,16 +96,6 @@ public final class Mixins {
     public static void addConfiguration(String configFile) {
         Mixins.createConfiguration(configFile, null, MixinEnvironment.getDefaultEnvironment());
     }
-
-    /**
-     * Add a mixin configuration resource
-     *
-     * @param configFile path to configuration resource
-     * @param modId id of the provider mod or null
-     */
-    public static void addConfiguration(String configFile, String modId) {
-        Mixins.createConfiguration(configFile, modId, MixinEnvironment.getDefaultEnvironment());
-    }
     
     @Deprecated
     static void addConfiguration(String configFile, MixinEnvironment fallback) {

--- a/src/main/java/org/spongepowered/asm/mixin/Mixins.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Mixins.java
@@ -24,6 +24,11 @@
  */
 package org.spongepowered.asm.mixin;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.launch.GlobalProperties;
@@ -31,11 +36,6 @@ import org.spongepowered.asm.launch.GlobalProperties.Keys;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import org.spongepowered.asm.mixin.transformer.ClassInfo;
 import org.spongepowered.asm.mixin.transformer.Config;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
 
 /**
  * Entry point for registering global mixin resources. Compatibility with
@@ -84,7 +84,7 @@ public final class Mixins {
     public static void addConfigurations(String modId, String... configFiles) {
         MixinEnvironment fallback = MixinEnvironment.getDefaultEnvironment();
         for (String configFile : configFiles) {
-            Mixins.createConfiguration(configFile, modId,fallback);
+            Mixins.createConfiguration(configFile, modId, fallback);
         }
     }
     

--- a/src/main/java/org/spongepowered/asm/mixin/Mixins.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Mixins.java
@@ -80,7 +80,9 @@ public final class Mixins {
      * 
      * @param modId id of the provider mod or null
      * @param configFiles config resources to add
+     * @deprecated only available on fabric's fork of mixin
      */
+    @Deprecated
     public static void addConfigurations(String modId, String... configFiles) {
         MixinEnvironment fallback = MixinEnvironment.getDefaultEnvironment();
         for (String configFile : configFiles) {

--- a/src/main/java/org/spongepowered/asm/mixin/Mixins.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Mixins.java
@@ -24,11 +24,6 @@
  */
 package org.spongepowered.asm.mixin;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.launch.GlobalProperties;
@@ -36,6 +31,11 @@ import org.spongepowered.asm.launch.GlobalProperties.Keys;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import org.spongepowered.asm.mixin.transformer.ClassInfo;
 import org.spongepowered.asm.mixin.transformer.Config;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Entry point for registering global mixin resources. Compatibility with
@@ -72,9 +72,19 @@ public final class Mixins {
      * @param configFiles config resources to add
      */
     public static void addConfigurations(String... configFiles) {
+        addConfigurations(null, configFiles);
+    }
+
+    /**
+     * Add multiple configurations
+     * 
+     * @param modId id of the provider mod or null
+     * @param configFiles config resources to add
+     */
+    public static void addConfigurations(String modId, String... configFiles) {
         MixinEnvironment fallback = MixinEnvironment.getDefaultEnvironment();
         for (String configFile : configFiles) {
-            Mixins.createConfiguration(configFile, fallback);
+            Mixins.createConfiguration(configFile, modId,fallback);
         }
     }
     
@@ -84,20 +94,30 @@ public final class Mixins {
      * @param configFile path to configuration resource
      */
     public static void addConfiguration(String configFile) {
-        Mixins.createConfiguration(configFile, MixinEnvironment.getDefaultEnvironment());
+        Mixins.createConfiguration(configFile, null, MixinEnvironment.getDefaultEnvironment());
+    }
+
+    /**
+     * Add a mixin configuration resource
+     *
+     * @param configFile path to configuration resource
+     * @param modId id of the provider mod or null
+     */
+    public static void addConfiguration(String configFile, String modId) {
+        Mixins.createConfiguration(configFile, modId, MixinEnvironment.getDefaultEnvironment());
     }
     
     @Deprecated
     static void addConfiguration(String configFile, MixinEnvironment fallback) {
-        Mixins.createConfiguration(configFile, fallback);
+        Mixins.createConfiguration(configFile, null, fallback);
     }
 
     @SuppressWarnings("deprecation")
-    private static void createConfiguration(String configFile, MixinEnvironment fallback) {
+    private static void createConfiguration(String configFile, String modId, MixinEnvironment fallback) {
         Config config = null;
         
         try {
-            config = Config.create(configFile, fallback);
+            config = Config.create(configFile, modId, fallback);
         } catch (Exception ex) {
             Mixins.logger.error("Error encountered reading mixin config " + configFile + ": " + ex.getClass().getName() + " " + ex.getMessage(), ex);
         }

--- a/src/main/java/org/spongepowered/asm/mixin/extensibility/IMixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/extensibility/IMixinConfig.java
@@ -89,4 +89,11 @@ public interface IMixinConfig {
      */
     public abstract Set<String> getTargets();
 
+    /**
+     * Get the id of the provider mod, if available
+     *
+     * @return the id of the provider mod or null if no plugin
+     */
+    public abstract String getModId();
+
 }

--- a/src/main/java/org/spongepowered/asm/mixin/extensibility/IMixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/extensibility/IMixinConfig.java
@@ -92,7 +92,7 @@ public interface IMixinConfig {
     /**
      * Get the id of the provider mod, if available
      *
-     * @return the id of the provider mod or null if no plugin
+     * @return the id of the provider mod or null if it wasn't provided
      */
     public abstract String getModId();
 

--- a/src/main/java/org/spongepowered/asm/mixin/extensibility/IMixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/extensibility/IMixinConfig.java
@@ -93,7 +93,9 @@ public interface IMixinConfig {
      * Get the id of the provider mod, if available
      *
      * @return the id of the provider mod or null if it wasn't provided
+     * @deprecated only available on fabric's fork of mixin
      */
+    @Deprecated
     public abstract String getModId();
 
 }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/Config.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/Config.java
@@ -24,15 +24,16 @@
  */
 package org.spongepowered.asm.mixin.transformer;
 
-import com.google.common.base.Strings;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.launch.MixinInitialisationError;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfig;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.google.common.base.Strings;
 
 /**
  * Handle for marshalling mixin configs outside of the transformer package
@@ -131,7 +132,7 @@ public class Config {
     /**
      * Factory method, create a config from the specified config file and fail
      * over to the specified environment if no selector is present in the config
-     *
+     * 
      * @param configFile config resource
      * @param outer failover environment
      * @return new config or null if invalid config version
@@ -203,7 +204,7 @@ public class Config {
 
     /**
      * Factory method, create a config from the specified config resource
-     *
+     * 
      * @param configFile config resource
      * @param modId id of the provider mod or null
      * @return new config or null if invalid config version 

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/Config.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/Config.java
@@ -150,6 +150,7 @@ public class Config {
      * @param modId id of the provider mod or null
      * @param outer failover environment
      * @return new config or null if invalid config version
+     * @deprecated only available on fabric's fork of mixin
      */
     @Deprecated
     public static Config create(String configFile, String modId, MixinEnvironment outer) {

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/Config.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/Config.java
@@ -24,16 +24,15 @@
  */
 package org.spongepowered.asm.mixin.transformer;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.launch.MixinInitialisationError;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfig;
 
-import com.google.common.base.Strings;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Handle for marshalling mixin configs outside of the transformer package
@@ -132,20 +131,34 @@ public class Config {
     /**
      * Factory method, create a config from the specified config file and fail
      * over to the specified environment if no selector is present in the config
-     * 
+     *
      * @param configFile config resource
      * @param outer failover environment
      * @return new config or null if invalid config version
      */
     @Deprecated
     public static Config create(String configFile, MixinEnvironment outer) {
+        return Config.create(configFile, null, outer);
+    }
+
+    /**
+     * Factory method, create a config from the specified config file and fail
+     * over to the specified environment if no selector is present in the config
+     * 
+     * @param configFile config resource
+     * @param modId id of the provider mod or null
+     * @param outer failover environment
+     * @return new config or null if invalid config version
+     */
+    @Deprecated
+    public static Config create(String configFile, String modId, MixinEnvironment outer) {
         Config config = Config.allConfigs.get(configFile);
         if (config != null) {
             return config;
         }
         
         try {
-            config = MixinConfig.create(configFile, outer);
+            config = MixinConfig.create(configFile, modId, outer);
             if (config != null) {
                 Config.allConfigs.put(config.getName(), config);
             }
@@ -186,6 +199,17 @@ public class Config {
      */
     public static Config create(String configFile) {
         return MixinConfig.create(configFile, MixinEnvironment.getDefaultEnvironment());
+    }
+
+    /**
+     * Factory method, create a config from the specified config resource
+     *
+     * @param configFile config resource
+     * @param modId id of the provider mod or null
+     * @return new config or null if invalid config version 
+     */
+    public static Config create(String configFile, String modId) {
+        return MixinConfig.create(configFile, modId, MixinEnvironment.getDefaultEnvironment());
     }
 
 }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/Config.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/Config.java
@@ -202,15 +202,4 @@ public class Config {
         return MixinConfig.create(configFile, MixinEnvironment.getDefaultEnvironment());
     }
 
-    /**
-     * Factory method, create a config from the specified config resource
-     * 
-     * @param configFile config resource
-     * @param modId id of the provider mod or null
-     * @return new config or null if invalid config version 
-     */
-    public static Config create(String configFile, String modId) {
-        return MixinConfig.create(configFile, modId, MixinEnvironment.getDefaultEnvironment());
-    }
-
 }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
@@ -24,17 +24,18 @@
  */
 package org.spongepowered.asm.mixin.transformer;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
-import com.google.gson.Gson;
-import com.google.gson.annotations.SerializedName;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.launch.MixinInitialisationError;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.InsnList;
-import org.spongepowered.asm.launch.MixinInitialisationError;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel;
 import org.spongepowered.asm.mixin.MixinEnvironment.Option;
@@ -55,20 +56,11 @@ import org.spongepowered.asm.service.MixinService;
 import org.spongepowered.asm.util.CompareUtil;
 import org.spongepowered.asm.util.VersionNumber;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
 
 /**
  * Mixin configuration bundle

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
@@ -133,7 +133,7 @@ public class MixinProcessor {
         }
 
         public String getErrorMessage(IMixinInfo mixin, IMixinConfig config, Phase phase) {
-            return String.format("Mixin [%s] from phase [%s] in config [%s] FAILED during %s", mixin, phase, config, this.name());
+            return String.format("Mixin [%s] from phase [%s] in config [%s] provided by [%s] FAILED during %s", mixin, phase, config, config.getName(), this.name());
         }
         
     }
@@ -518,7 +518,7 @@ public class MixinProcessor {
                 this.handleMixinPrepareError(config, ex, environment);
             } catch (Exception ex) {
                 String message = ex.getMessage();
-                MixinProcessor.logger.error("Error encountered whilst initialising mixin config '" + config.getName() + "': " + message, ex);
+                MixinProcessor.logger.error("Error encountered whilst initialising mixin config '" + config.getName() + "', provided by '" + config.getModId() + "': " + message, ex);
             }
         }
         
@@ -545,7 +545,7 @@ public class MixinProcessor {
                 this.handleMixinPrepareError(config, ex, environment);
             } catch (Exception ex) {
                 String message = ex.getMessage();
-                MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName() + "': " + message, ex);
+                MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName()  + "', provided by '" + config.getModId() + "': " + message, ex);
             }
         }
         
@@ -618,6 +618,7 @@ public class MixinProcessor {
                 .kv("Action", errorPhase.name())
                 .kv("Mixin", mixin.getClassName())
                 .kv("Config", config.getName())
+                .kv("ModId", config.getModId())
                 .kv("Phase", phase)
                 .hr('-')
                 .add("    %s", ex.getClass().getName())

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
@@ -133,7 +133,9 @@ public class MixinProcessor {
         }
 
         public String getErrorMessage(IMixinInfo mixin, IMixinConfig config, Phase phase) {
-            return String.format("Mixin [%s] from phase [%s] in config [%s] provided by [%s] FAILED during %s", mixin, phase, config, config.getName(), this.name());
+            if (config.getModId() != null)
+                return String.format("Mixin [%s] from phase [%s] in config [%s] provided by [%s] FAILED during %s", mixin, phase, config, config.getModId(), this.name());
+            return String.format("Mixin [%s] from phase [%s] in config [%s] FAILED during %s", mixin, phase, config, this.name());
         }
         
     }
@@ -518,7 +520,9 @@ public class MixinProcessor {
                 this.handleMixinPrepareError(config, ex, environment);
             } catch (Exception ex) {
                 String message = ex.getMessage();
-                MixinProcessor.logger.error("Error encountered whilst initialising mixin config '" + config.getName() + "', provided by '" + config.getModId() + "': " + message, ex);
+                if (config.getModId() != null)
+                    MixinProcessor.logger.error("Error encountered whilst initialising mixin config '" + config.getName() + "', provided by '" + config.getModId() + "': " + message, ex);
+                MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName() + "': " + message, ex);
             }
         }
         
@@ -545,7 +549,9 @@ public class MixinProcessor {
                 this.handleMixinPrepareError(config, ex, environment);
             } catch (Exception ex) {
                 String message = ex.getMessage();
-                MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName()  + "', provided by '" + config.getModId() + "': " + message, ex);
+                if (config.getModId() != null)
+                    MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName() + "', provided by '" + config.getModId() + "': " + message, ex);
+                MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName()  + "': " + message, ex);
             }
         }
         
@@ -618,7 +624,7 @@ public class MixinProcessor {
                 .kv("Action", errorPhase.name())
                 .kv("Mixin", mixin.getClassName())
                 .kv("Config", config.getName())
-                .kv("ModId", config.getModId())
+                .kv("ModId", String.valueOf(config.getModId()))
                 .kv("Phase", phase)
                 .hr('-')
                 .add("    %s", ex.getClass().getName())

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
@@ -133,9 +133,7 @@ public class MixinProcessor {
         }
 
         public String getErrorMessage(IMixinInfo mixin, IMixinConfig config, Phase phase) {
-            if (config.getModId() != null)
-                return String.format("Mixin [%s] from phase [%s] in config [%s] provided by [%s] FAILED during %s", mixin, phase, config, config.getModId(), this.name());
-            return String.format("Mixin [%s] from phase [%s] in config [%s] FAILED during %s", mixin, phase, config, this.name());
+            return String.format("Mixin [%s] from phase [%s] in config [%s] provided by [%s] FAILED during %s", mixin, phase, config, config.getModId(), this.name());
         }
         
     }
@@ -520,11 +518,7 @@ public class MixinProcessor {
                 this.handleMixinPrepareError(config, ex, environment);
             } catch (Exception ex) {
                 String message = ex.getMessage();
-                if (config.getModId() != null) {
-                    MixinProcessor.logger.error("Error encountered whilst initialising mixin config '" + config.getName() + "', provided by '" + config.getModId() + "': " + message, ex);
-                } else {
-                    MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName() + "': " + message, ex);
-                }
+                MixinProcessor.logger.error("Error encountered whilst initialising mixin config '" + config.getName() + "', provided by '" + config.getModId() + "': " + message, ex);
             }
         }
         
@@ -551,11 +545,7 @@ public class MixinProcessor {
                 this.handleMixinPrepareError(config, ex, environment);
             } catch (Exception ex) {
                 String message = ex.getMessage();
-                if (config.getModId() != null) {
-                    MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName() + "', provided by '" + config.getModId() + "': " + message, ex);
-                } else {
-                    MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName()  + "': " + message, ex);
-                }
+                MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName() + "', provided by '" + config.getModId() + "': " + message, ex);
             }
         }
         

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
@@ -520,9 +520,11 @@ public class MixinProcessor {
                 this.handleMixinPrepareError(config, ex, environment);
             } catch (Exception ex) {
                 String message = ex.getMessage();
-                if (config.getModId() != null)
+                if (config.getModId() != null) {
                     MixinProcessor.logger.error("Error encountered whilst initialising mixin config '" + config.getName() + "', provided by '" + config.getModId() + "': " + message, ex);
-                MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName() + "': " + message, ex);
+                } else {
+                    MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName() + "': " + message, ex);
+                }
             }
         }
         
@@ -549,9 +551,11 @@ public class MixinProcessor {
                 this.handleMixinPrepareError(config, ex, environment);
             } catch (Exception ex) {
                 String message = ex.getMessage();
-                if (config.getModId() != null)
+                if (config.getModId() != null) {
                     MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName() + "', provided by '" + config.getModId() + "': " + message, ex);
-                MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName()  + "': " + message, ex);
+                } else {
+                    MixinProcessor.logger.error("Error encountered during mixin config postInit step'" + config.getName()  + "': " + message, ex);
+                }
             }
         }
         


### PR DESCRIPTION
Various mixin `addConfiguration` methods now take an optional `modId` parameter.