### PR TITLE
Allow interface Mixins

### DIFF
--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerInjector.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerInjector.java
@@ -152,10 +152,6 @@ class AnnotatedMixinElementHandlerInjector extends AnnotatedMixinElementHandler 
     }
 
     public void registerInjector(AnnotatedElementInjector elem) {
-        if (this.mixin.isInterface()) {
-            this.ap.printMessage(Kind.ERROR, "Injector in interface is unsupported", elem.getElement());
-        }
-        
         for (String reference : elem.getAnnotation().<String>getList("method")) {
             ITargetSelector targetSelector = TargetSelector.parse(reference);
             
@@ -260,10 +256,6 @@ class AnnotatedMixinElementHandlerInjector extends AnnotatedMixinElementHandler 
      * and process the references
      */
     public void registerInjectionPoint(AnnotatedElementInjectionPoint elem, String format) {
-        if (this.mixin.isInterface()) {
-            this.ap.printMessage(Kind.ERROR, "Injector in interface is unsupported", elem.getElement());
-        }
-        
         if (!elem.shouldRemap()) {
             return;
         }

--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGenerator.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGenerator.java
@@ -26,11 +26,11 @@ package org.spongepowered.asm.mixin.gen;
 
 import java.util.ArrayList;
 
+import org.apache.logging.log4j.LogManager;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.MethodNode;
-import org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException;
-import org.spongepowered.asm.mixin.refmap.IMixinContext;
+import org.spongepowered.asm.mixin.gen.throwables.InvalidAccessorException;
 import org.spongepowered.asm.util.asm.ASM;
 
 /**
@@ -54,10 +54,12 @@ public abstract class AccessorGenerator {
     }
 
     protected void checkModifiers() {
-        if (this.info.isStatic() && !this.targetIsStatic) {
-            IMixinContext context = this.info.getContext();
-            throw new InvalidInjectionException(context, String.format("%s is invalid. Accessor method is%s static but the target is not.",
-                    this.info, this.info.isStatic() ? "" : " not"));
+        if (this.info.isStatic() != this.targetIsStatic) {
+            if (!this.targetIsStatic) {
+                throw new InvalidAccessorException(this.info, String.format("%s is invalid. Accessor method is static but the target is not.", this.info));
+            } else {
+                LogManager.getLogger("mixin").info("{} could be static as its target is", this.info);
+            }
         }
     }
 
@@ -70,7 +72,7 @@ public abstract class AccessorGenerator {
      */
     protected final MethodNode createMethod(int maxLocals, int maxStack) {
         MethodNode method = this.info.getMethod();
-        MethodNode accessor = new MethodNode(ASM.API_VERSION, (method.access & ~Opcodes.ACC_ABSTRACT) | Opcodes.ACC_SYNTHETIC, method.name,
+        MethodNode accessor = new MethodNode(ASM.API_VERSION, (method.access & ~Opcodes.ACC_ABSTRACT) | Opcodes.ACC_SYNTHETIC | (this.targetIsStatic ? Opcodes.ACC_STATIC : 0), method.name,
                 method.desc, null, null);
         accessor.visibleAnnotations = new ArrayList<AnnotationNode>();
         accessor.visibleAnnotations.add(this.info.getAnnotation());

--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGenerator.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGenerator.java
@@ -58,7 +58,7 @@ public abstract class AccessorGenerator {
             if (!this.targetIsStatic) {
                 throw new InvalidAccessorException(this.info, String.format("%s is invalid. Accessor method is static but the target is not.", this.info));
             } else {
-                LogManager.getLogger("mixin").info("{} could be static as its target is", this.info);
+                LogManager.getLogger("mixin").info("{} should be static as its target is", this.info);
             }
         }
     }
@@ -72,7 +72,7 @@ public abstract class AccessorGenerator {
      */
     protected final MethodNode createMethod(int maxLocals, int maxStack) {
         MethodNode method = this.info.getMethod();
-        MethodNode accessor = new MethodNode(ASM.API_VERSION, (method.access & ~Opcodes.ACC_ABSTRACT) | Opcodes.ACC_SYNTHETIC | (this.targetIsStatic ? Opcodes.ACC_STATIC : 0), method.name,
+        MethodNode accessor = new MethodNode(ASM.API_VERSION, (method.access & ~Opcodes.ACC_ABSTRACT) | Opcodes.ACC_SYNTHETIC, method.name,
                 method.desc, null, null);
         accessor.visibleAnnotations = new ArrayList<AnnotationNode>();
         accessor.visibleAnnotations.add(this.info.getAnnotation());

--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGeneratorFieldSetter.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGeneratorFieldSetter.java
@@ -31,6 +31,7 @@ import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.VarInsnNode;
 import org.spongepowered.asm.mixin.MixinEnvironment.Option;
+import org.spongepowered.asm.mixin.gen.throwables.InvalidAccessorException;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.transformer.ClassInfo.Method;
 import org.spongepowered.asm.mixin.transformer.MixinTargetContext;
@@ -52,6 +53,12 @@ public class AccessorGeneratorFieldSetter extends AccessorGeneratorField {
     
     @Override
     public void validate() {
+        if (Bytecode.hasFlag(this.info.getClassNode(), Opcodes.ACC_INTERFACE)) {
+            //This will result in a ClassFormatError when the class is verified
+            throw new InvalidAccessorException(info, String.format("%s tried to change interface field %s::%s",
+                    this.info, this.info.getClassNode().name, this.targetField.name));
+        }
+
         super.validate();
         
         Method method = this.info.getClassInfo().findMethod(this.info.getMethod());

--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGeneratorMethodProxy.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGeneratorMethodProxy.java
@@ -75,9 +75,10 @@ public class AccessorGeneratorMethodProxy extends AccessorGenerator {
             method.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
         }
         Bytecode.loadArgs(this.argTypes, method.instructions, this.targetIsStatic ? 0 : 1);
+        boolean isInterface = Bytecode.hasFlag(this.info.getClassNode(), Opcodes.ACC_INTERFACE);
         boolean isPrivate = Bytecode.hasFlag(this.targetMethod, Opcodes.ACC_PRIVATE);
-        int opcode = this.targetIsStatic ? Opcodes.INVOKESTATIC : (isPrivate ? Opcodes.INVOKESPECIAL : Opcodes.INVOKEVIRTUAL);
-        method.instructions.add(new MethodInsnNode(opcode, this.info.getClassNode().name, this.targetMethod.name, this.targetMethod.desc, false));
+        int opcode = this.targetIsStatic ? Opcodes.INVOKESTATIC : isInterface ? Opcodes.INVOKEINTERFACE : (isPrivate ? Opcodes.INVOKESPECIAL : Opcodes.INVOKEVIRTUAL);
+        method.instructions.add(new MethodInsnNode(opcode, this.info.getClassNode().name, this.targetMethod.name, this.targetMethod.desc, isInterface));
         method.instructions.add(new InsnNode(this.returnType.getOpcode(Opcodes.IRETURN)));
         return method;
     }

--- a/src/main/java/org/spongepowered/asm/mixin/injection/code/Injector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/code/Injector.java
@@ -405,9 +405,10 @@ public abstract class Injector {
      * @return injected insn node
      */
     protected AbstractInsnNode invokeHandler(InsnList insns, MethodNode handler) {
+        boolean isInterface = Bytecode.hasFlag(classNode, Opcodes.ACC_INTERFACE);
         boolean isPrivate = (handler.access & Opcodes.ACC_PRIVATE) != 0;
-        int invokeOpcode = this.isStatic ? Opcodes.INVOKESTATIC : isPrivate ? Opcodes.INVOKESPECIAL : Opcodes.INVOKEVIRTUAL;
-        MethodInsnNode insn = new MethodInsnNode(invokeOpcode, this.classNode.name, handler.name, handler.desc, false);
+        int invokeOpcode = this.isStatic ? Opcodes.INVOKESTATIC : isInterface ? Opcodes.INVOKEINTERFACE : isPrivate ? Opcodes.INVOKESPECIAL : Opcodes.INVOKEVIRTUAL;
+        MethodInsnNode insn = new MethodInsnNode(invokeOpcode, this.classNode.name, handler.name, handler.desc, isInterface);
         insns.add(insn);
         this.info.addCallbackInvocation(handler);
         return insn;

--- a/src/main/java/org/spongepowered/asm/mixin/struct/MemberRef.java
+++ b/src/main/java/org/spongepowered/asm/mixin/struct/MemberRef.java
@@ -27,6 +27,7 @@ package org.spongepowered.asm.mixin.struct;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
+import org.spongepowered.asm.mixin.transformer.ClassInfo;
 import org.spongepowered.asm.mixin.transformer.throwables.MixinTransformerError;
 import org.spongepowered.asm.util.Bytecode;
 
@@ -241,7 +242,7 @@ public abstract class MemberRef {
             if (tag == 0) {
                 throw new MixinTransformerError("Invalid opcode " + Bytecode.getOpcodeName(opcode) + " for method handle " + this.handle + ".");
             }
-            boolean itf = tag == Opcodes.H_INVOKEINTERFACE;
+            boolean itf = this.handle.isInterface();
             this.handle = new org.objectweb.asm.Handle(tag, this.handle.getOwner(), this.handle.getName(), this.handle.getDesc(), itf);
         }
 
@@ -252,7 +253,8 @@ public abstract class MemberRef {
 
         @Override
         public void setOwner(String owner) {
-            boolean itf = this.handle.getTag() == Opcodes.H_INVOKEINTERFACE;
+            boolean itf = this.handle.isInterface();
+            assert ClassInfo.forName(owner).isInterface() == itf;
             this.handle = new org.objectweb.asm.Handle(this.handle.getTag(), owner, this.handle.getName(), this.handle.getDesc(), itf);
         }
 
@@ -263,7 +265,7 @@ public abstract class MemberRef {
 
         @Override
         public void setName(String name) {
-            boolean itf = this.handle.getTag() == Opcodes.H_INVOKEINTERFACE;
+            boolean itf = this.handle.isInterface();
             this.handle = new org.objectweb.asm.Handle(this.handle.getTag(), this.handle.getOwner(), name, this.handle.getDesc(), itf);
         }
 
@@ -274,7 +276,7 @@ public abstract class MemberRef {
 
         @Override
         public void setDesc(String desc) {
-            boolean itf = this.handle.getTag() == Opcodes.H_INVOKEINTERFACE;
+            boolean itf = this.handle.isInterface();
             this.handle = new org.objectweb.asm.Handle(this.handle.getTag(), this.handle.getOwner(), this.handle.getName(), desc, itf);
         }
     }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPostProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPostProcessor.java
@@ -213,7 +213,7 @@ class MixinPostProcessor implements MixinConfig.IListener {
         Type[] args = Type.getArgumentTypes(methodNode.desc);
         Type returnType = Type.getReturnType(methodNode.desc);
         Bytecode.loadArgs(args, methodNode.instructions, 0);
-        methodNode.instructions.add(new MethodInsnNode(Opcodes.INVOKESTATIC, targetClass.getName(), method.getName(), methodNode.desc, false));
+        methodNode.instructions.add(new MethodInsnNode(Opcodes.INVOKESTATIC, targetClass.getName(), method.getName(), methodNode.desc, targetClass.isInterface()));
         methodNode.instructions.add(new InsnNode(returnType.getOpcode(Opcodes.IRETURN)));
         methodNode.maxStack = Bytecode.getFirstNonArgLocalIndex(args, false);
         methodNode.maxLocals = 0;

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorInterface.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorInterface.java
@@ -27,6 +27,8 @@ package org.spongepowered.asm.mixin.transformer;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.FieldNode;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel.LanguageFeature;
 import org.spongepowered.asm.mixin.transformer.ClassInfo.Method;
 import org.spongepowered.asm.mixin.transformer.MixinInfo.MixinClassNode;
 import org.spongepowered.asm.mixin.transformer.MixinInfo.MixinMethodNode;
@@ -58,8 +60,11 @@ class MixinPreProcessorInterface extends MixinPreProcessorStandard {
     protected void prepareMethod(MixinMethodNode mixinMethod, Method method) {
         // Userland interfaces should not have non-public methods except for lambda bodies
         if (!Bytecode.hasFlag(mixinMethod, Opcodes.ACC_PUBLIC) && !Bytecode.hasFlag(mixinMethod, Opcodes.ACC_SYNTHETIC)) {
-            throw new InvalidInterfaceMixinException(this.mixin, "Interface mixin contains a non-public method! Found " + method + " in "
-                    + this.mixin);
+            //On versions that support it private methods are also allowed
+            if (!Bytecode.hasFlag(mixinMethod, Opcodes.ACC_PRIVATE) || !MixinEnvironment.getCompatibilityLevel().supports(LanguageFeature.PRIVATE_METHODS_IN_INTERFACES)) {
+                throw new InvalidInterfaceMixinException(this.mixin, "Interface mixin contains a non-public method! Found " + method + " in "
+                        + this.mixin);
+            }
         }
         
         super.prepareMethod(mixinMethod, method);


### PR DESCRIPTION
Reimplements #13 more expansively, allows things like...
```java
public interface Interface {
	String GENERATED_CONSTANT = generate();

	private static String generate() {
		return "generated";
	}

	public static String make() {
		return "made";
	}

	void eat(int food);

	default int next(int start) {
		return start + 1;
	}
}

@Mixin(Interface.class)
interface InterfaceMixin {
	@Inject(method = "make", at = @At("RETURN"), cancellable = true)
	private static void remake(CallbackInfoReturnable<String> call) {
		call.setReturnValue("remade");
	}

	@ModifyVariable(method = "next", argsOnly = true, at = @At("HEAD"))
	default int switchNext(int start) {
		hit();
		return start - 1;
	}

	@Shadow
	private static String generate() {
		throw new AssertionError();
	}

	private void hit() {
		System.out.println(generate());

		Arrays.asList("one", "two", "three").removeIf(thing -> {
			//No more IncompatibleClassChangeErrors from lambdas in interfaces
			return false; //The list is fixed length so we don't actually want it to succeed
		});
	}
}
```