### PR TITLE
Avoid creating CallbackInfos where they are unused

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
@@ -213,15 +213,17 @@ public class CallbackInjector extends Injector {
                 this.invoke.add(this.localTypes.length - this.frameSize);
             }
 
+            //If the handler doesn't captureArgs, the CallbackInfo(Returnable) will be the first LVT slot, otherwise it will be at the target's frameSize
+            int callbackInfoSlot = handlerArgs.length == 1 ? Bytecode.isStatic(handler) ? 0 : 1 : frameSize;
             boolean seenCallbackInfoUse = false;
             for (AbstractInsnNode insn : handler.instructions) {
                 //Look for anywhere the CallbackInfo(Returnable) is loaded in the handler, it's unused if it is never loaded in
-                if (insn.getType() == AbstractInsnNode.VAR_INSN && insn.getOpcode() == Opcodes.ALOAD && ((VarInsnNode) insn).var == frameSize) {
+                if (insn.getType() == AbstractInsnNode.VAR_INSN && insn.getOpcode() == Opcodes.ALOAD && ((VarInsnNode) insn).var == callbackInfoSlot) {
                     seenCallbackInfoUse = true;
                     break;
                 }
             }
-            //System.out.printf("%s does%s use it's CallbackInfo%s%n", info, seenCallbackInfoUse ? "" : "n't", Type.VOID_TYPE.equals(target.returnType) ? "" : "Returnable");
+            Injector.logger.debug("{} does{} use it's CallbackInfo{}", info, seenCallbackInfoUse ? "" : "n't", Type.VOID_TYPE == target.returnType ? "" : "Returnable");
             usesCallbackInfo = seenCallbackInfoUse;
         }
 

--- a/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
@@ -163,6 +163,12 @@ public class CallbackInjector extends Injector {
          */
         private boolean captureArgs = true;
 
+        /**
+         * Whether {@link #handler} uses the {@link CallbackInfo}/
+         * {@link CallbackInfoReturnable} it would normally be passed
+         */
+        final boolean usesCallbackInfo;
+
         Callback(MethodNode handler, Target target, final InjectionNode node, final LocalVariableNode[] locals, boolean captureLocals) {
             this.handler = handler;
             this.target = target;
@@ -206,6 +212,17 @@ public class CallbackInjector extends Injector {
             if (this.canCaptureLocals) {
                 this.invoke.add(this.localTypes.length - this.frameSize);
             }
+
+            boolean seenCallbackInfoUse = false;
+            for (AbstractInsnNode insn : handler.instructions) {
+                //Look for anywhere the CallbackInfo(Returnable) is loaded in the handler, it's unused if it is never loaded in
+                if (insn.getType() == AbstractInsnNode.VAR_INSN && insn.getOpcode() == Opcodes.ALOAD && ((VarInsnNode) insn).var == frameSize) {
+                    seenCallbackInfoUse = true;
+                    break;
+                }
+            }
+            //System.out.printf("%s does%s use it's CallbackInfo%s%n", info, seenCallbackInfoUse ? "" : "n't", Type.VOID_TYPE.equals(target.returnType) ? "" : "Returnable");
+            usesCallbackInfo = seenCallbackInfoUse;
         }
 
         /**
@@ -520,12 +537,14 @@ public class CallbackInjector extends Injector {
             }
         }
         
-        this.dupReturnValue(callback);
-        if (this.cancellable || this.totalInjections > 1) {
-            this.createCallbackInfo(callback, true);
+        if (callback.usesCallbackInfo) {
+            this.dupReturnValue(callback);
+            if (this.cancellable || this.totalInjections > 1) {
+                this.createCallbackInfo(callback, true);
+            }
         }
         this.invokeCallback(callback, callbackMethod);
-        this.injectCancellationCode(callback);
+        if (callback.usesCallbackInfo) this.injectCancellationCode(callback);
         
         callback.inject();
         this.info.notifyInjected(callback.target);
@@ -635,7 +654,9 @@ public class CallbackInjector extends Injector {
      * @param callback callback handle
      */
     private void loadOrCreateCallbackInfo(final Callback callback) {
-        if (this.cancellable || this.totalInjections > 1) {
+        if (!callback.usesCallbackInfo) {
+            callback.add(new InsnNode(Opcodes.ACONST_NULL));
+        } else if (this.cancellable || this.totalInjections > 1) {
             callback.add(new VarInsnNode(Opcodes.ALOAD, this.callbackInfoVar), false, true);
         } else {
             this.createCallbackInfo(callback, false);


### PR DESCRIPTION
Sodium has used this as a reason to `@Overwrite` rather than `@Inject` in hot code, testing on AoF3 shows that just over 50% of all injectors don't use the `CallbackInfo(Returnable)` they're passed (900ish do compared to 1000ish which don't)