### PR TITLE
Publish processor jar to Maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -444,6 +444,7 @@ publishing {
 
             artifact sourceJar
             artifact javadocJar
+            artifact shadowJar
             artifact(proguardFile) {
                 builtBy stagingProguardJar
                 classifier = "universal"


### PR DESCRIPTION
related to https://github.com/FabricMC/fabric-mixin-compile-extensions/issues/14. This should make the loom's ap configuration much cleaner.

~~Also, is this possible to backport to 0.9.4+mixin-0.8.2 (in the sense that publish a processor jar for this version)?~~ Since it's a pain to release for an older version (by modmuss50), I think the best way is to release it for the next version.