### PR TITLE
Fix annotating fields with @Unique

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
@@ -487,6 +487,7 @@ class MixinApplicatorStandard {
             if (target == null) {
                 // This is just a local field, so add it
                 this.targetClass.fields.add(field);
+                mixin.fieldMerged(field);
                 
                 if (field.signature != null) {
                     if (this.mergeSignatures) {

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
@@ -615,6 +615,7 @@ class MixinPreProcessorStandard {
             FieldNode target = context.findField(mixinField, shadow);
             if (target == null) {
                 if (shadow == null) {
+                    context.addMixinField(mixinField);
                     continue;
                 }
                 target = context.findRemappedField(mixinField);
@@ -638,6 +639,7 @@ class MixinPreProcessorStandard {
                     MixinPreProcessorStandard.logger.log(this.mixin.getLoggingLevel(), "Renaming @Unique field {}{} to {} in {}",
                             mixinField.name, mixinField.desc, uniqueName, this.mixin);
                     mixinField.name = field.renameTo(uniqueName);
+                    context.addMixinField(mixinField);
                     continue;
                 }
 

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -256,6 +256,25 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
                 "sessionId", this.sessionId);
     }
     
+    void addMixinField(FieldNode field) {
+        Annotations.setVisible(field, MixinMerged.class, "mixin", this.getClassName());
+        this.getTarget().addMixinField(field);
+    }
+
+    /**
+     * Callback from the applicator which notifies us that a field was merged
+     * 
+     * @param field merged field
+     */
+    void fieldMerged(FieldNode field) {
+        this.getTarget().fieldMerged(field);
+
+        Annotations.setVisible(field, MixinMerged.class,
+                "mixin", this.getClassName(),
+                "priority", this.getPriority(),
+                "sessionId", this.sessionId);
+    }
+
     /* (non-Javadoc)
      * @see java.lang.Object#toString()
      */
@@ -1046,7 +1065,7 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
             }
         }
         
-        return this.getTarget().findAliasedField(aliases, field.desc);
+        return this.getTarget().findField(aliases, field.desc);
     }
 
     FieldNode findRemappedField(FieldNode field) {

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/TargetClassContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/TargetClassContext.java
@@ -128,6 +128,13 @@ final class TargetClassContext extends ClassContext implements ITargetClassConte
     private final Set<MethodNode> mixinMethods = new HashSet<MethodNode>();
     
     /**
+     * Information about fields which have been discovered by mixin
+     * preprocessors in this pass but which have not yet been merged into the
+     * target class. 
+     */
+    private final Set<FieldNode> mixinFields = new HashSet<>();
+
+    /**
      * Exceptions which were suppressed during mixin application because they
      * were raised by an optional mixin 
      */
@@ -278,6 +285,21 @@ final class TargetClassContext extends ClassContext implements ITargetClassConte
         }
     }
     
+    /**
+     * Add the specified field to the pending mixin fields set
+     * 
+     * @param field field to add
+     */
+    void addMixinField(FieldNode field) {
+        this.mixinFields.add(field);
+    }
+
+    void fieldMerged(FieldNode field) {
+        if (!this.mixinFields.remove(field)) {
+            TargetClassContext.logger.debug("Unexpected: Merged unregistered field {} {} in {}", field.desc, field.name, this);
+        }
+    }
+
     MethodNode findMethod(Deque<String> aliases, String desc) {
         return this.findAliasedMethod(aliases, desc, true);
     }
@@ -309,6 +331,10 @@ final class TargetClassContext extends ClassContext implements ITargetClassConte
         return this.findAliasedMethod(aliases, desc);
     }
     
+    FieldNode findField(Deque<String> aliases, String desc) {
+        return this.findAliasedField(aliases, desc, true);
+    }
+
     /**
      * Finds a field in the target class
      * 
@@ -317,6 +343,10 @@ final class TargetClassContext extends ClassContext implements ITargetClassConte
      * @return Target field  or null if not found
      */
     FieldNode findAliasedField(Deque<String> aliases, String desc) {
+        return this.findAliasedField(aliases, desc, false);
+    }
+
+    private FieldNode findAliasedField(Deque<String> aliases, String desc, boolean includeMixinFields) {
         String alias = aliases.poll();
         if (alias == null) {
             return null;
@@ -328,7 +358,15 @@ final class TargetClassContext extends ClassContext implements ITargetClassConte
             }
         }
 
-        return this.findAliasedField(aliases, desc);
+        if (includeMixinFields) {
+            for (FieldNode target : this.mixinFields) {
+                if (target.name.equals(alias) && target.desc.equals(desc)) {
+                    return target;
+                }
+            } 
+        }
+
+        return this.findAliasedField(aliases, desc, includeMixinFields);
     }
 
     /**
@@ -416,6 +454,10 @@ final class TargetClassContext extends ClassContext implements ITargetClassConte
             if (!method.name.startsWith("<")) {
                 TargetClassContext.logger.debug("Unexpected: Registered method {}{} in {} was not merged", method.name, method.desc, this);
             }
+        }
+
+        for (FieldNode field : this.mixinFields) {
+            TargetClassContext.logger.debug("Unexpected: Registered field {} {} in {} was not merged", field.desc, field.name, this);
         }
     }
 

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/TargetClassContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/TargetClassContext.java
@@ -132,7 +132,7 @@ final class TargetClassContext extends ClassContext implements ITargetClassConte
      * preprocessors in this pass but which have not yet been merged into the
      * target class. 
      */
-    private final Set<FieldNode> mixinFields = new HashSet<>();
+    private final Set<FieldNode> mixinFields = new HashSet<FieldNode>();
 
     /**
      * Exceptions which were suppressed during mixin application because they


### PR DESCRIPTION
Fixes things like the second crash in FabricMC/Fabric#1676

Right now Mixin will mangle any injector handlers (no matter the access) and non-public methods annotated with `@Unique` so mixins don't conflict with each other, or the class they are added to. For fields however, only existing fields on the target class will be checked to avoid collisions, meaning the following example behaves unexpectedly:
```java
public class Class {
	public static void call() {
	}
}
@Mixin(Class.class)
abstract class ClassMixinA {
	@Unique
	private static String message = "Mixin A";

	@Inject(method = "call", at = @At("HEAD"))
	private static void onCall(CallbackInfo call) {
		System.out.println("Mixin A says ".concat(message));
	}
}
@Mixin(Class.class)
abstract class ClassMixinB {
	@Unique
	private static String message = "Mixin B";

	@Inject(method = "call", at = @At("HEAD"))
	private static void onCall(CallbackInfo call) {
		System.out.println("Mixin B says ".concat(message));
	}
}
```
The result of `Class.call()` is `Mixin A says Mixin B, Mixin B says Mixin B`, the second mixin has overwritten the first. This PR ensures the second's field is mangled out of the way so you get the expected result of `Mixin A says Mixin A, Mixin B says Mixin B`.