### PR TITLE
Fix LOAD slice only when not running in compat mode

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/modify/BeforeLoadLocal.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/modify/BeforeLoadLocal.java
@@ -203,7 +203,7 @@ public class BeforeLoadLocal extends LocalVariableInjectionPoint {
     boolean find(InjectionInfo info, InsnList insns, Collection<AbstractInsnNode> nodes, Target target) {
         SearchState state = new SearchState();
 
-        ListIterator<AbstractInsnNode> iter = insns.iterator();
+        ListIterator<AbstractInsnNode> iter = (org.spongepowered.asm.mixin.FabricUtil.getCompatibility(info) >= org.spongepowered.asm.mixin.FabricUtil.COMPATIBILITY_0_10_0 ? insns : target.method.instructions).iterator();
         while (iter.hasNext()) {
             AbstractInsnNode insn = iter.next();
             if (state.isPendingCheck()) {


### PR DESCRIPTION
This undoes a77b39022e9814a27691d3162002f566b06aed4a when running in compat mode. Not ideal, but resolves incompatibility for https://github.com/CammiePone/Arcanus/blob/68142f63f52fc61d57c8719dcd3a0d0d357df726/src/main/java/dev/cammiescorner/arcanus/core/mixin/LivingEntityMixin.java#L54-L57 and potentially other mods.