### PR TITLE
Fix File/Memory leak in Annotation Processor.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ sourceSets {
     ap {
         compileClasspath += main.output
         ext.languageVersion = 8
-        ext.compatibility = '1.6'
+        ext.compatibility = '1.8'
     }
     fernflower {
         compileClasspath += main.output
@@ -177,6 +177,7 @@ dependencies {
     // Annotation Processor
     apImplementation "org.ow2.asm:asm-tree:$asmVersion"
     apImplementation guava
+    apImplementation gson
     
     // Fernflower decompiler
     fernflowerImplementation 'org.jetbrains:intellij-fernflower:1.0.0.9'


### PR DESCRIPTION
Mixin's AP requires the minecraft jar + deps on the AP classpath to generate a refmap. These files are then opened by the classloader.

TargetMap uses Java's object Serialization to save/load itself from files. When doing so it gets placed into ObjectStreamClass.Caches, this does not get garbage collected enough to allow the Classloader to close, and thus close the file handles it has open.

This commit uses Gson to read/write TargetMap to prevent this class form being added to the global JVM cache.