### PR TITLE
Warn likely failed interface shadows

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorInterface.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorInterface.java
@@ -81,6 +81,11 @@ class MixinApplicatorInterface extends MixinApplicatorStandard {
                 if (entry.getValue().isDecoratedMutable()) {
                     this.logger.error("Ignoring illegal @Mutable on {}:{} in {}", shadow.name, shadow.desc, mixin);
                 }
+
+                //If a final field has a primitive value assigned with the declaration, the value is likely inlined where the field is used
+                if (shadow.value != null) {
+                    this.logger.warn("@Shadow field {}:{} in {} has an inlinable value set, is this intended?", shadow.name, shadow.desc, mixin);
+                }
             } else {
                 //This is silently ignored for normal classes, but the only fields an interface has will be shadowed
                 this.logger.warn("Unable to find target for @Shadow {}:{} in {}", shadow.name, shadow.desc, mixin);


### PR DESCRIPTION
All interface fields are static and final, so any constant primitive value assigned to them will be set in the field declaration, and probably inlined when compiled to avoid reading the field. In this situation the shadowed value won't be taken, instead using whatever constant value it was compiled with instead. Of course, a compiler might not do so, but javac at least will.

The "proper" way to do this, given field and interface Mixins are not friends at the best of times, is to set the shadow fields with a method so that the value isn't constant:
```java
@Mixin(Interface.class)
interface MyInterfaceMixin {
    @Shadow
    String SPECIAL_FIELD = dummyMethod();

    //Something that uses SPECIAL_FIELD...
}

public static String dummyMethod() {
    return null; //The value doesn't matter as the call will be removed when the mixin is applied
}
```