### PR TITLE
Fix #80

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
@@ -473,14 +473,16 @@ public class CallbackInjector extends Injector {
     
     @Override
     protected void preInject(Target target, InjectionNode node) {
-        if ((this.localCapture.isCaptureLocals() || this.localCapture.isPrintLocals()) && !node.hasDecoration(CallbackInjector.LOCALS_KEY)) {
-            LocalVariableNode[] locals = Locals.getLocalsAt(this.classNode, target.method, node.getCurrentTarget(), org.spongepowered.asm.mixin.FabricUtil.getCompatibility(info));
+        int fabricCompatibility = org.spongepowered.asm.mixin.FabricUtil.getCompatibility(info);
+        String decorationKey = CallbackInjector.LOCALS_KEY + ":" + fabricCompatibility;
+        if ((this.localCapture.isCaptureLocals() || this.localCapture.isPrintLocals()) && !node.hasDecoration(decorationKey)) {
+            LocalVariableNode[] locals = Locals.getLocalsAt(this.classNode, target.method, node.getCurrentTarget(), fabricCompatibility);
             for (int j = 0; j < locals.length; j++) {
                 if (locals[j] != null && locals[j].desc != null && locals[j].desc.startsWith("Lorg/spongepowered/asm/mixin/injection/callback/")) {
                     locals[j] = null;
                 }
             }
-            node.<LocalVariableNode[]>decorate(CallbackInjector.LOCALS_KEY, locals);
+            node.<LocalVariableNode[]>decorate(decorationKey, locals);
         }
     }
 
@@ -491,7 +493,7 @@ public class CallbackInjector extends Injector {
      */
     @Override
     protected void inject(Target target, InjectionNode node) {
-        LocalVariableNode[] locals = node.<LocalVariableNode[]>getDecoration(CallbackInjector.LOCALS_KEY);
+        LocalVariableNode[] locals = node.<LocalVariableNode[]>getDecoration(CallbackInjector.LOCALS_KEY + ":" + org.spongepowered.asm.mixin.FabricUtil.getCompatibility(info));
         this.inject(new Callback(this.methodNode, target, node, locals, this.localCapture.isCaptureLocals()));
     }
 


### PR DESCRIPTION
This fixes the issue where two methods inject to the same method, and the first method to inject gets to pick the compatibility mode of the locals.

## Issue Example
Mod A injects to `method()` with Loader <0.12.0
Mod B injects to `method()` with Loader >=0.12.0

When each of them tries to grab the local, the first one to be able to inject will decide the compatibility mode of the locals. This issue was unnoticed since `TargetClassContext#mixins` is a `SortedSet` and has a consistent order between launches.

## Issues with this PR
Mods previously built against another library would receive the library's locals, this is the case with Architectury API, where it injects to the same method as Fabric API, causing Architectury API (which depends on new LVT), to get the old LVT.

With this PR, Architectury API will once again get the new LVT for the method, however, this would make it crash.
This issue is repeated against Cloth API as well, and I don't know the number of mods that would experience an issue due to this.

### Additional Info
Fabric Loader currently uses Mixin 0.8.4, and the main branch of Fabric Mixin is 0.8.5, so this PR is based on that.