### PR TITLE
Fix invalid cross-mixin interaction in interface applicator preparation.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorInterface.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorInterface.java
@@ -123,22 +123,21 @@ class MixinApplicatorInterface extends MixinApplicatorStandard {
      */
     @Override
     protected void prepareInjections(MixinTargetContext mixin) {
-        for (MethodNode method : this.targetClass.methods) {
-            try {
-                InjectionInfo injectInfo = InjectionInfo.parse(mixin, method);
-                if (injectInfo != null) {
-                    //Make sure we're running on a Java version which supports interfaces having method bodies
-                    if (!MixinEnvironment.getCompatibilityLevel().supports(LanguageFeatures.METHODS_IN_INTERFACES)) {
-                        throw new InvalidInterfaceMixinException(mixin, injectInfo + " is not supported on interface mixin method " + method.name);
-                    }
-                }
-            } catch (InvalidInjectionException ex) {
-                String description = ex.getContext() != null ? ex.getContext().toString() : "Injection";
-                throw new InvalidInterfaceMixinException(mixin, description + " is not supported in interface mixin");
-            }
+        try {
+            super.prepareInjections(mixin);
+        } catch (InvalidInjectionException ex) {
+            String description = ex.getContext() != null ? ex.getContext().toString() : "Injection";
+            throw new InvalidInterfaceMixinException(mixin, description + " is not supported in interface mixin", ex);
         }
 
-        super.prepareInjections(mixin);
+        InjectionInfo injectInfo = mixin.getFirstInjectionInfo();
+
+        if (injectInfo != null) {
+            //Make sure we're running on a Java version which supports interfaces having method bodies
+            if (!MixinEnvironment.getCompatibilityLevel().supports(LanguageFeatures.METHODS_IN_INTERFACES)) {
+                throw new InvalidInterfaceMixinException(mixin, injectInfo + " is not supported on interface mixin method " + injectInfo.getMethodName());
+            }
+        }
     }
     
     @Override

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -1353,6 +1353,10 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
         }
     }
 
+    InjectionInfo getFirstInjectionInfo() {
+        return injectors.isEmpty() ? null : injectors.get(0);
+    }
+
     /**
      * Apply injectors discovered in the {@link #prepareInjections()} pass
      */


### PR DESCRIPTION
The previous implementation gathers InjectionInfos for all annotated
methods in the target class, which after a previous injection means that
it'll see injected methods from unrelated mixins if they happen to
target the same class. This caused it to analyze foreign injections
without the proper refmap and mixin association.