### PR TITLE
Rename mixin target mapid system property to fix clashes

### DIFF
--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixins.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixins.java
@@ -86,7 +86,7 @@ import com.google.common.collect.ImmutableList.Builder;
  */
 final class AnnotatedMixins implements IMixinAnnotationProcessor, ITokenProvider, ITypeHandleProvider, IJavadocProvider {
 
-    private static final String MAPID_SYSTEM_PROPERTY = "mixin.target.mapid";
+    private static final String MAPID_SYSTEM_PROPERTY = "fabric.mixin.target.mapid";
     
     private static final String RECOMMENDED_MIXINGRADLE_VERSION = "0.7";
 


### PR DESCRIPTION
Fabric mixin stores data in a different format than Sponge mixin expects, leading to clashes when both try to read and write to the same file.