### PR TITLE
Fix package-private mixin inheritance

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInheritanceTracker.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInheritanceTracker.java
@@ -84,7 +84,7 @@ public enum MixinInheritanceTracker implements IListener {
 				int ownerSplit = owner.lastIndexOf('/');
 				int childSplit = node.name.lastIndexOf('/');
 				//There is a reasonable chance mixins are in the same package, so it is viable that a package private method is overridden
-				if (ownerSplit != childSplit || (ownerSplit > 0 && !owner.regionMatches(0, child.getName(), 0, ownerSplit + 1))) break;
+				if (ownerSplit != childSplit || (ownerSplit > 0 && !owner.regionMatches(0, node.name, 0, ownerSplit + 1))) break;
 
 			default:
 				out.add(method);


### PR DESCRIPTION
Two lines above I'd fixed `childSplit` in 974a7599b4cfafa51f49433a7d3456ae0eddd9cf, but apparently not the line immediately below.

Fixes an NPE calling `new B().make()` in the following scenario:
```java
public class A {
	public String make() {
		return "A";
	}
}

public class B extends A {
}

@Mixin(A.class)
abstract class AMixin {
	@Inject(method = "make", at = @At("RETURN"), cancellable = true)
	void onInit(CallbackInfoReturnable<String> call) {
	}
}

@Mixin(B.class)
abstract class BMixin extends AMixin {
	@Override
	void onInit(CallbackInfoReturnable<String> call) {
		call.setReturnValue("B Mixin!");
	}
}
```