### PR TITLE
Fix unique fields conflicting where they shouldn't

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
@@ -628,7 +628,7 @@ class MixinPreProcessorStandard {
                 mixinField.name = field.renameTo(target.name);
             }
             
-            if (!Bytecode.compareFlags(mixinField, target, Opcodes.ACC_STATIC)) {
+            if (isShadow && !Bytecode.compareFlags(mixinField, target, Opcodes.ACC_STATIC)) {
                 throw new InvalidMixinException(this.mixin, String.format("STATIC modifier of @Shadow field %s in %s does not match the target",
                         mixinField.name, this.mixin));
             }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
@@ -628,11 +628,6 @@ class MixinPreProcessorStandard {
                 mixinField.name = field.renameTo(target.name);
             }
             
-            if (isShadow && !Bytecode.compareFlags(mixinField, target, Opcodes.ACC_STATIC)) {
-                throw new InvalidMixinException(this.mixin, String.format("STATIC modifier of @Shadow field %s in %s does not match the target",
-                        mixinField.name, this.mixin));
-            }
-            
             if (field.isUnique()) {
                 if ((mixinField.access & (Opcodes.ACC_PRIVATE | Opcodes.ACC_PROTECTED)) != 0) {
                     String uniqueName = context.getUniqueName(mixinField);
@@ -653,6 +648,14 @@ class MixinPreProcessorStandard {
 
                 iter.remove();
                 continue;
+            } else if (!Bytecode.compareFlags(mixinField, target, Opcodes.ACC_STATIC)) {
+            	if (isShadow) {
+	                throw new InvalidMixinException(this.mixin, String.format("STATIC modifier of @Shadow field %s in %s does not match the target",
+	                        mixinField.name, this.mixin));
+            	} else {
+            		throw new InvalidMixinException(this.mixin, String.format("Field %s in %s conflicts with %sstatic field in the target (%s)",
+            				mixinField.name, mixin, Bytecode.isStatic(target) ? "" : "non-", context.getTarget()));
+            	}
             }
             
             // Check that the shadow field has a matching descriptor


### PR DESCRIPTION
Mixin tests if all fields which match name & descriptor with an existing field in the target class (including previously applied mixins) also match the static flag, which in the case of `@Unique` fields is pointless as they will immediately have their name changed to avoid conflicting.

Fixes `InvalidMixinException: STATIC modifier of @Shadow field staticThing in modid.mixins.json:MixinA from mod test-mod does not match the target` being thrown in the following scenario:
```java
public class A {
	public static String[] staticThing;
	public String nonstaticThing;
}

@Mixin(A.class)
abstract class AMixin {
	@Unique
	private String[] staticThing;
	@Unique
	private static String nonstaticThing;
}
```
Without also causing a `ClassFormatError: Duplicate field name&signature in class file A` in the following case (which throws the same as above currently):
```java
@Mixin(A.class)
abstract class AlternativeAMixin {
	private String[] staticThing;
	private static String nonstaticThing;
}
```