### PR TITLE
Fix package-private unique fields

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
@@ -634,7 +634,7 @@ class MixinPreProcessorStandard {
             }
             
             if (field.isUnique()) {
-                if ((mixinField.access & (Opcodes.ACC_PRIVATE | Opcodes.ACC_PROTECTED)) != 0) {
+                if (Bytecode.getVisibility(mixinField).isLessThan(Visibility.PUBLIC)) {
                     String uniqueName = context.getUniqueName(mixinField);
                     MixinPreProcessorStandard.logger.log(this.mixin.getLoggingLevel(), "Renaming @Unique field {}{} to {} in {}",
                             mixinField.name, mixinField.desc, uniqueName, this.mixin);


### PR DESCRIPTION
Mixin avoids renaming public method and fields marked with `@Unique`, the logic being if they are public they could be used outside of their containing mixin so the renaming wouldn't apply to those situations. The check for methods will remap all other accesses, the check for fields however misses package private access.

For reference, this is the current logging in a scenario demonstrating the inconsistency:
```
[DEBUG] [FabricLoader/Mixin]: Renaming @Unique method thing()Ljava/lang/String; to md9aeb2b$thing$1 in modid.mixins.json:AMixin from mod test-mod
[WARN] [FabricLoader/Mixin]: Discarding @Unique public field thing in modid.mixins.json:AMixin from mod test-mod because it already exists in A. Note that declared FIELD INITIALISERS will NOT be removed!
```
```java
public class A {
	public String thing;

	public String thing() {
		return null;
	}
}

@Mixin(A.class)
abstract class AMixin {
	@Unique
	String thing;

	@Unique
	String thing() {
		return null;
	}
}
```
Like #92 this is just an oversight in Mixin so should be upstreamed too