### PR TITLE
Auto-prefix mod handlers & unique annotated methods

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/FabricUtil.java
+++ b/src/main/java/org/spongepowered/asm/mixin/FabricUtil.java
@@ -38,7 +38,11 @@ public final class FabricUtil {
     public static final int COMPATIBILITY_LATEST = COMPATIBILITY_0_10_0;
 
     public static String getModId(IMixinConfig config) {
-        return getDecoration(config, KEY_MOD_ID, "(unknown)");
+        return getModId(config, "(unknown)");
+    }
+
+    public static String getModId(IMixinConfig config, String defaultValue) {
+        return getDecoration(config, KEY_MOD_ID, defaultValue);
     }
     
     public static String getModId(ISelectorContext context) {


### PR DESCRIPTION
Fairly simple principal, where an added handler or `@Unique` annotated method is added by a mod's mixin, include the responsible mod's name. Aims to avoid double prefixing where a mod has correctly prefixed already; which lets mods choose to keep prefixing without duplicating the name.

In practice, given the target class
```java
public class Target {
	public String field;

	public static String staticMethod() {
		return "thing";
	}

	public Target() {
	}

	public String method() {
		return "thing";
	}
}
```
and mixin for mod `test_mod`:
```java
@Mixin(Target.class)
abstract class TargetMixin {
	@Unique
	private String field;

	@Inject(method = "staticMethod", at = @At("HEAD"))
	private static void onStaticMethod(CallbackInfoReturnable<String> call) {
	}

	@Unique
	private static String staticMethod() {
		return "different thing";
	}

	@Inject(method = "<init>", at = @At("TAIL"))
	private void onConstruct(CallbackInfo call) {
	}

	@Inject(method = "method", at = @At("HEAD"))
	private void onMethod(CallbackInfoReturnable<String> call) {
	}

	@Unique
	private String method() {
		return "different thing";
	}
}
```
On application you will get this as a result
```java
public class Target {
    public String field;
    @Unique
    @MixinMerged(
        mixin = "com.chocohead.test.mixin.TargetMixin",
        priority = 1000,
        sessionId = "cfc6ca47-e9f0-45fe-bd90-ac70be1c1c4b"
    )
    private String fd1c1c4b$field$0; //@Unique fields aren't changed as they won't appear in stack traces, easy enough to change if desired

    public static String staticMethod() {
        handler$zza000$test_mod$onStaticMethod(null);
        return "thing";
    }

    public Target() {
        this.handler$zza000$test_mod$onConstruct(null);
    }

    public String method() {
        this.handler$zza000$test_mod$onMethod(null);
        return "thing";
    }

    @Unique
    @MixinMerged(
        mixin = "com.chocohead.test.mixin.TargetMixin",
        priority = 1000,
        sessionId = "cfc6ca47-e9f0-45fe-bd90-ac70be1c1c4b"
    )
    private static String md1c1c4b$test_mod$staticMethod$0() {
        return "different thing";
    }

    @MixinMerged(
        mixin = "com.chocohead.test.mixin.TargetMixin",
        priority = 1000,
        sessionId = "cfc6ca47-e9f0-45fe-bd90-ac70be1c1c4b"
    )
    private static void handler$zza000$test_mod$onStaticMethod(CallbackInfoReturnable<String> call) {
    }

    @MixinMerged(
        mixin = "com.chocohead.test.mixin.TargetMixin",
        priority = 1000,
        sessionId = "cfc6ca47-e9f0-45fe-bd90-ac70be1c1c4b"
    )
    private void handler$zza000$test_mod$onConstruct(CallbackInfo call) {
    }

    @MixinMerged(
        mixin = "com.chocohead.test.mixin.TargetMixin",
        priority = 1000,
        sessionId = "cfc6ca47-e9f0-45fe-bd90-ac70be1c1c4b"
    )
    private void handler$zza000$test_mod$onMethod(CallbackInfoReturnable<String> call) {
    }

    @Unique
    @MixinMerged(
        mixin = "com.chocohead.test.mixin.TargetMixin",
        priority = 1000,
        sessionId = "cfc6ca47-e9f0-45fe-bd90-ac70be1c1c4b"
    )
    private String md1c1c4b$test_mod$method$1() {
        return "different thing";
    }
}
```
Thus all the added methods gaining `test_mod$` to their name. Combined with the existing `@MixinMerged` annotation you should have a pretty good idea of where a method has come from just based on the exported class. Naturally at runtime you can [try harder still](https://github.com/Chocohead/Crafty-Crashes), but this is much more portable.

As Fabric validates mod IDs, there is no risk of one including a [forbidden character](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.2.2) and upsetting the JVM's verifier, unlike mod names.