### PR TITLE
Fix memory leak for injectors without a group

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/struct/InjectorGroupInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/struct/InjectorGroupInfo.java
@@ -49,7 +49,7 @@ public class InjectorGroupInfo {
         
         private static final long serialVersionUID = 1L;
         
-        private static final InjectorGroupInfo NO_GROUP = new InjectorGroupInfo("NONE", true);
+        private final InjectorGroupInfo noGroup = new InjectorGroupInfo("NONE", true);
         
         @Override
         public InjectorGroupInfo get(Object key) {
@@ -94,7 +94,7 @@ public class InjectorGroupInfo {
          */
         public InjectorGroupInfo parseGroup(AnnotationNode annotation, String defaultGroup) {
             if (annotation == null) {
-                return InjectorGroupInfo.Map.NO_GROUP;
+                return noGroup;
             }
             
             String name = Annotations.<String>getValue(annotation, "name");


### PR DESCRIPTION
The `injectorGroups` map grouping injectors by their `@Group` is created in `MixinTargetContext`'s constructor for each mixin on application. Said context lasts only during mixin application (`MixinPreProcessorStandard#createContextFor` -> `MixinInfo#createContextFor` -> `MixinApplicatorStandard#apply`), thus the map also only lasts this long.

`NO_GROUP` is returned for all injectors which don't have a `@Group` (i.e. most of them), so most will end up being categorised there. Because `NO_GROUP` is static it will survive the map that returned it and so retain the injectors it contains after their respective `MixinTargetContext`s are finished with. Whilst this doesn't matter to the group validation (otherwise it probably would have been noticed sooner), it will be leaking the memory to keep `InjectionInfo`s around for no reason.


For reference [Memory Leak Fix resolves this](https://github.com/fxmorin/MemoryLeakFix/blob/dev/src/main/java/ca/fxco/memoryleakfix/MemoryLeakFix.java#L32-L37) by applying all mixins with `MixinEnvironment#audit` then clearing `NO_GROUP` out.