### PR TITLE
Fix implicit `@Accessors` and `@Invokers`

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorInfo.java
@@ -50,6 +50,7 @@ import org.spongepowered.asm.mixin.transformer.MixinTargetContext;
 import org.spongepowered.asm.service.MixinService;
 import org.spongepowered.asm.util.Annotations;
 import org.spongepowered.asm.util.Bytecode;
+import org.spongepowered.asm.util.asm.MethodNodeEx;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
@@ -355,7 +356,7 @@ public class AccessorInfo extends SpecialMethodInfo {
      * <tt>foo</tt> for example.  
      */
     protected String inflectTarget() {
-        return AccessorInfo.inflectTarget(this.method.name, this.type, this.toString(), this,
+        return AccessorInfo.inflectTarget(MethodNodeEx.getName(this.method), this.type, this.toString(), this,
                 this.mixin.getEnvironment().getOption(Option.DEBUG_VERBOSE));
     }
 

--- a/src/main/java/org/spongepowered/asm/mixin/gen/InvokerInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/InvokerInfo.java
@@ -37,6 +37,7 @@ import org.spongepowered.asm.mixin.injection.struct.MemberInfo;
 import org.spongepowered.asm.mixin.transformer.MixinTargetContext;
 import org.spongepowered.asm.util.Bytecode;
 import org.spongepowered.asm.util.Constants;
+import org.spongepowered.asm.util.asm.MethodNodeEx;
 
 /**
  * Information about an invoker
@@ -54,7 +55,7 @@ class InvokerInfo extends AccessorInfo {
             return this.initType(mappedReference.replace('.',  '/'), this.mixin.getTargetClassRef());
         }
         
-        AccessorName accessorName = AccessorName.of(this.method.name, false);
+        AccessorName accessorName = AccessorName.of(MethodNodeEx.getName(this.method), false);
         if (accessorName != null) {
             for (String prefix : AccessorType.OBJECT_FACTORY.getExpectedPrefixes()) {
                 if (prefix.equals(accessorName.prefix)) {


### PR DESCRIPTION
Fixes a bug in #97: The handler's method name is used to guess the target field/method, which is no good if it guessing with the mod suffix on the end too.

Possibly might still present issues running remapped, in which case either `MethodMapper#getUniqueName` needs to stick the suffix after `_$md` when `preservePrefix` is `true`, or `AccessorInfo$AccessorName#PATTERN` adjusted to account for (potential) leading parts before `_$md`.

Tested with target:
```java
public class Target {
	static String staticField = "thing";
	static String SHOUTING_STATIC_FIELD = "HERE";
	String field = "thing";
	String SHOUTING_FIELD = "HERE";

	static String staticMethod() {
		return staticField;
	}

	static String SHOUTING_STATIC_METHOD() {
		return SHOUTING_STATIC_FIELD;
	}

	Target() {
	}

	String method() {
		return field;
	}

	String SHOUTING_METHOD() {
		return SHOUTING_FIELD;
	}
}
```
and mixin:
```java
@Mixin(Target.class)
public interface TargetMixin {
	@Accessor
	static String getStaticField() {
		throw new AssertionError();
	}

	@Accessor
	static void setStaticField(String value) {
		throw new AssertionError();
	}

	@Accessor
	static String getSHOUTING_STATIC_FIELD() {
		throw new AssertionError();
	}

	@Accessor
	static void setSHOUTING_STATIC_FIELD(String value) {
		throw new AssertionError();
	}

	@Accessor
	String getField();

	@Accessor
	void setField(String value);

	@Accessor
	String getSHOUTING_FIELD();

	@Accessor
	void setSHOUTING_FIELD(String value);

	@Invoker
	static Target createTarget() {
		throw new AssertionError();
	}

	@Invoker
	String callMethod();

	@Invoker
	String callSHOUTING_METHOD();
}
```
On application makes the following all run without issue:
```java
TargetMixin.setStaticField(TargetMixin.getStaticField());
TargetMixin.setSHOUTING_STATIC_FIELD(TargetMixin.getSHOUTING_STATIC_FIELD());
TargetMixin test = (TargetMixin) TargetMixin.createTarget();
test.setField(test.getField());
test.setSHOUTING_FIELD(test.getSHOUTING_FIELD());
test.callMethod();
test.callSHOUTING_METHOD();
```