### PR TITLE
Fix adding fields to classes with more than one constructor 

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
@@ -970,18 +970,15 @@ class MixinApplicatorStandard {
         }
 
         for (AbstractInsnNode node : initialiser) {
-            AbstractInsnNode imACloneNow;
+            if (node instanceof LabelNode) {
+                // Fabric: Merge cloned labels instead of skipping them.
+                // continue;
+            }
             if (node instanceof JumpInsnNode) {
                 // Fabric: Jumps cause no issues if labels are cloned properly and should not be needlessly restricted.
                 // throw new InvalidMixinException(mixin, "Unsupported JUMP opcode in initialiser in " + mixin);
             }
-            if (node instanceof LabelNode) {
-                // Fabric: Merge cloned labels instead of skipping them.
-                imACloneNow = labels.get(node);
-            } else {
-                imACloneNow = node.clone(labels);
-            }
-
+            AbstractInsnNode imACloneNow = node.clone(labels);
             ctor.instructions.insert(insn, imACloneNow);
             insn = imACloneNow;
         }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
@@ -959,7 +959,7 @@ class MixinApplicatorStandard {
         // Fabric: also clone labels from the initialiser as they will be merged.
         for (AbstractInsnNode node : initialiser) {
             if (node instanceof LabelNode) {
-                labels.put((LabelNode) node, new LabelNode(((LabelNode) node).getLabel()));
+                labels.put((LabelNode) node, new LabelNode());
             }
         }
         


### PR DESCRIPTION
Fixes a bug in #90: When calculating the stack map for generating frames, `MethodWriter` (through `Frame`) will store information within `Label`s about their line number, in & outgoing stack size, and other calculation data. In doing this it means if you then reuse a `Label` for another method's stack map calculations, it won't clear all this existing data out and you can get strange results (mainly `ArrayIndexOutofBoundsException`s). This isn't an issue for `Bytecode#cloneLabels` purely as despite reusing the input labels, they are never re-used by Mixin outside of the original method.

Allows injecting the following target:
```java
public class Target {
	public Target() {
	}

	public Target(String thing) {
	}
}
```
with the following mixin:
```java
@Mixin(Target.class)
abstract class TargetMixin {
	@Unique //@Unique purely being optional here, but it stops IDE warnings about being unused
	private boolean one = false;
	@Unique
	private boolean two = false;
	@Unique
	private boolean three = Math.random() > 0.5;
}
```

The PR also reduces the changes relative to upstream just because it's possible without being uglier.