### PR TITLE
Fix: Resolve method references not being correctly remapped in initializers

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -875,9 +875,8 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
     }
     
     private void updateBinding(MethodNode method, MemberRef methodRef, Traversal traversal) {
-        if (Constants.CTOR.equals(method.name)
-                || methodRef.getOwner().equals(this.getTarget().getClassRef())
-                || this.getTarget().getClassRef().startsWith("<")) {
+        if (Constants.CTOR.equals(methodRef.getName())
+                || methodRef.getOwner().equals(this.getTarget().getClassRef())) {
             return;
         }
         


### PR DESCRIPTION
Example case:
```java
@Mixin(Screen.class)
public abstract class ScreenMixin {
    @Shadow protected abstract <T extends AbstractButtonWidget> T addButton(T button);
}
```
+
```java
@Mixin(TitleScreen.class)
public abstract class ExampleMixin extends ScreenMixin {
    private final UnaryOperator<AbstractButtonWidget> test = this::addButton;
}
```
gives an `IllegalClassLoadError` because the `INVOKEDYNAMIC` instruction still references the mixin.

According to Mumfrey the intention of the check was to bypass `super()` calls, which it still does by checking the member's name instead of the containing method's name.