### PR TITLE
proguard.conf: Keep module-info

### DIFF
--- a/proguard.conf
+++ b/proguard.conf
@@ -10,6 +10,8 @@
     public protected *;
 }
 
+-keep class module-info
+
 -keepclassmembers enum ** {
     public static **[] values();
     public static ** valueOf(java.lang.String);


### PR DESCRIPTION
It's not referenced by other classes, so it gets deleted by default. See https://stackoverflow.com/a/50541568.