### PR TITLE
Fix: Add a LVT entry for the marshal var in CallbackInjector if necessary.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
@@ -750,6 +750,8 @@ public class CallbackInjector extends Injector {
         if (store) {
             callback.target.addLocalVariable(this.callbackInfoVar, "callbackInfo" + this.callbackInfoVar, "L" + this.callbackInfoClass + ";");
             callback.add(new VarInsnNode(Opcodes.ASTORE, this.callbackInfoVar), false, false, head);
+        } else if (callback.isAtReturn) {
+            callback.target.addLocalVariable(this.callbackInfoVar, "returnValue" + this.callbackInfoVar, callback.target.returnType.getDescriptor());
         }
     }
 


### PR DESCRIPTION
Closes #110.
This is only a problem in the first place because Mumfrey did `preInject` wrong but fixing that would diverge far more from master. It doesn't occur there because the CallbackInfo is normally (always?) stored.