### PR TITLE
Fixes and improvements for retrieving IMixinInfo from ClassInfo

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
@@ -941,8 +941,8 @@ public final class ClassInfo {
     /**
      * Get all mixins which target this class
      */
-    Set<MixinInfo> getMixins() {
-        return this.isMixin ? Collections.<MixinInfo>emptySet() : Collections.<MixinInfo>unmodifiableSet(this.mixins);
+    public Set<IMixinInfo> getMixins() {
+        return this.isMixin ? Collections.<IMixinInfo>emptySet() : Collections.<IMixinInfo>unmodifiableSet(this.mixins);
     }
 
     /**
@@ -957,6 +957,13 @@ public final class ClassInfo {
      */
     public boolean isMixin() {
         return this.isMixin;
+    }
+
+    /**
+     * Get mixin metadata for this class, if it is a mixin
+     */
+    public IMixinInfo getMixinInfo() {
+        return this.mixin;
     }
     
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
@@ -1376,7 +1376,7 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
         }
         
         this.parent.postApply(transformedName, targetClass);
-        this.info.addAppliedMixin(this);
+        ClassInfo.fromClassNode(targetClass).addAppliedMixin(this);
     }
     
     /* (non-Javadoc)


### PR DESCRIPTION
In `MixinInfo#postApply`, the `MixinInfo` reference is being added to the `ClassInfo` of the mixin itself, rather than the classes the mixin is applied to. This means that `Mixins.getMixinsForClass` only returns `MixinInfo` on mixin classes themselves, not their target classes, and `ClassInfo#getAppliedMixins()` is empty for target classes.

The following 3 changes are made in this PR:

- Fix the behaviour to resolve the `ClassInfo` of the target class and add the `MixinInfo` to that.
- Allow external code to query the list of mixins that target a class, including mixins that were not applied, by exposing `getMixins` as a public method; this method wasn't used internally but exposing it allows external error handlers greater visibility of mixins targeting a class.
- Expose `ClassInfo.mixin` with `getMixinInfo` to allow external code to retrieve mixin metadata from a class. This supersedes the need for some other methods like `isMixin` and `isLoadable`, but these are kept for compatibility.

(upstream equivalent PR: https://github.com/SpongePowered/Mixin/pull/529)