### PR TITLE
Include the Gson module deps in the module-info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,7 @@ sourceSets {
         ext.languageVersion = 16
         ext.modularityExcluded = true // don't add ourselves
     }
+    modularityDummy {}
 }
 
 // Because Mixin aims to support a variety of environments, we have to be able to run with older versions of GSON and Guava that lack official module
@@ -364,7 +365,7 @@ if (JavaVersion.current().isJava8Compatible()) {
 }
 
 task stagingJar(type: ShadowJar) {
-    sourceSets.findAll { !(it.name =~ /example|test/) }.each {
+    sourceSets.findAll { !(it.name =~ /example|test|modularityDummy/) }.each {
         from it.output
     }
     configurations = [project.configurations.stagingJar]

--- a/src/modularity/java/module-info.java
+++ b/src/modularity/java/module-info.java
@@ -61,6 +61,12 @@ module org.spongepowered.mixin {
     requires static com.google.gson;
     requires static gson;
 
+    // Gson's module dependencies
+    // Optional dependency on java.sql
+    requires static java.sql;
+    // Optional dependency on jdk.unsupported for JDK's sun.misc.Unsafe
+    requires static jdk.unsupported;
+
     //
     // Exports
     //

--- a/src/modularity/java/module-info.java
+++ b/src/modularity/java/module-info.java
@@ -152,4 +152,6 @@ module org.spongepowered.mixin {
     provides org.spongepowered.tools.obfuscation.service.IObfuscationService
         with org.spongepowered.tools.obfuscation.mcp.ObfuscationServiceMCP,
              org.spongepowered.tools.obfuscation.fg3.ObfuscationServiceFG3;
+			 
+    uses org.spongepowered.include.com.google.common.base.PatternCompiler;
 }

--- a/src/modularityDummy/java/org/spongepowered/include/com/google/common/base/PatternCompiler.java
+++ b/src/modularityDummy/java/org/spongepowered/include/com/google/common/base/PatternCompiler.java
@@ -1,0 +1,5 @@
+package org.spongepowered.include.com.google.common.base;
+
+// Dummy public class so that the module can declare a uses directive for it
+public interface PatternCompiler {
+}

--- a/src/modularityDummy/java/org/spongepowered/include/com/google/common/base/PatternCompiler.java
+++ b/src/modularityDummy/java/org/spongepowered/include/com/google/common/base/PatternCompiler.java
@@ -1,3 +1,28 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package org.spongepowered.include.com.google.common.base;
 
 // Dummy public class so that the module can declare a uses directive for it


### PR DESCRIPTION
Gson declares these dependencies, and gson is being shaded and relocated by mixin