### PR TITLE
Fix/modifyarg(s) after redirect

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgInjector.java
@@ -27,13 +27,13 @@ package org.spongepowered.asm.mixin.injection.invoke;
 import java.util.Arrays;
 import java.util.List;
 
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.spongepowered.asm.mixin.injection.InjectionPoint;
 import org.spongepowered.asm.mixin.injection.InjectionPoint.RestrictTargetLevel;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.invoke.util.InvokeUtil;
 import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
 import org.spongepowered.asm.mixin.injection.struct.InjectionNodes.InjectionNode;
 import org.spongepowered.asm.mixin.injection.struct.Target;
@@ -110,12 +110,8 @@ public class ModifyArgInjector extends InvokeInjector {
     @Override
     protected void injectAtInvoke(Target target, InjectionNode node) {
         MethodInsnNode methodNode = (MethodInsnNode)node.getCurrentTarget();
-        Type[] originalArgs = Type.getArgumentTypes(((MethodInsnNode) node.getOriginalTarget()).desc);
-        Type[] currentArgs = Type.getArgumentTypes(methodNode.desc);
-        if (node.isReplaced() && node.hasDecoration(RedirectInjector.Meta.KEY) && methodNode.getOpcode() != Opcodes.INVOKESTATIC) {
-            // A redirect handler method for a virtual target will have an extra arg at the start that we don't care about.
-            currentArgs = Arrays.copyOfRange(currentArgs, 1, currentArgs.length);
-        }
+        Type[] originalArgs = InvokeUtil.getOriginalArgs(node);
+        Type[] currentArgs = InvokeUtil.getCurrentArgs(node);
         int argIndex = this.findArgIndex(target, originalArgs);
         InsnList insns = new InsnList();
         Extension extraLocals = target.extendLocals();

--- a/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgInjector.java
@@ -27,6 +27,7 @@ package org.spongepowered.asm.mixin.injection.invoke;
 import java.util.Arrays;
 import java.util.List;
 
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.MethodInsnNode;
@@ -109,15 +110,20 @@ public class ModifyArgInjector extends InvokeInjector {
     @Override
     protected void injectAtInvoke(Target target, InjectionNode node) {
         MethodInsnNode methodNode = (MethodInsnNode)node.getCurrentTarget();
-        Type[] args = Type.getArgumentTypes(methodNode.desc);
-        int argIndex = this.findArgIndex(target, args);
+        Type[] originalArgs = Type.getArgumentTypes(((MethodInsnNode) node.getOriginalTarget()).desc);
+        Type[] currentArgs = Type.getArgumentTypes(methodNode.desc);
+        if (node.isReplaced() && node.hasDecoration(RedirectInjector.Meta.KEY) && methodNode.getOpcode() != Opcodes.INVOKESTATIC) {
+            // A redirect handler method for a virtual target will have an extra arg at the start that we don't care about.
+            currentArgs = Arrays.copyOfRange(currentArgs, 1, currentArgs.length);
+        }
+        int argIndex = this.findArgIndex(target, originalArgs);
         InsnList insns = new InsnList();
         Extension extraLocals = target.extendLocals();
         
         if (this.singleArgMode) {
-            this.injectSingleArgHandler(target, extraLocals, args, argIndex, insns);
+            this.injectSingleArgHandler(target, extraLocals, currentArgs, argIndex, insns);
         } else {
-            this.injectMultiArgHandler(target, extraLocals, args, argIndex, insns);
+            this.injectMultiArgHandler(target, extraLocals, originalArgs, currentArgs, argIndex, insns);
         }
         
         target.insns.insertBefore(methodNode, insns);
@@ -138,17 +144,17 @@ public class ModifyArgInjector extends InvokeInjector {
     /**
      * Inject handler opcodes for a multi arg handler
      */
-    private void injectMultiArgHandler(Target target, Extension extraLocals, Type[] args, int argIndex, InsnList insns) {
-        if (!Arrays.equals(args, this.methodArgs)) {
+    private void injectMultiArgHandler(Target target, Extension extraLocals, Type[] originalArgs, Type[] currentArgs, int argIndex, InsnList insns) {
+        if (!Arrays.equals(originalArgs, this.methodArgs)) {
             throw new InvalidInjectionException(this.info, "@ModifyArg method " + this + " targets a method with an invalid signature "
-                    + Bytecode.getDescriptor(args) + ", expected " + Bytecode.getDescriptor(this.methodArgs));
+                    + Bytecode.getDescriptor(originalArgs) + ", expected " + Bytecode.getDescriptor(this.methodArgs));
         }
 
-        int[] argMap = this.storeArgs(target, args, insns, 0);
-        this.pushArgs(args, insns, argMap, 0, argIndex);
-        this.invokeHandlerWithArgs(args, insns, argMap, 0, args.length);
-        this.pushArgs(args, insns, argMap, argIndex + 1, args.length);
-        extraLocals.add((argMap[argMap.length - 1] - target.getMaxLocals()) + args[args.length - 1].getSize());
+        int[] argMap = this.storeArgs(target, currentArgs, insns, 0);
+        this.pushArgs(currentArgs, insns, argMap, 0, argIndex);
+        this.invokeHandlerWithArgs(originalArgs, insns, argMap, 0, originalArgs.length);
+        this.pushArgs(currentArgs, insns, argMap, argIndex + 1, currentArgs.length);
+        extraLocals.add((argMap[argMap.length - 1] - target.getMaxLocals()) + currentArgs[currentArgs.length - 1].getSize());
     }
 
     protected int findArgIndex(Target target, Type[] args) {

--- a/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgsInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgsInjector.java
@@ -33,12 +33,15 @@ import org.objectweb.asm.tree.VarInsnNode;
 import org.spongepowered.asm.mixin.injection.InjectionPoint.RestrictTargetLevel;
 import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.invoke.arg.ArgsClassGenerator;
+import org.spongepowered.asm.mixin.injection.invoke.util.InvokeUtil;
 import org.spongepowered.asm.mixin.injection.struct.InjectionInfo;
 import org.spongepowered.asm.mixin.injection.struct.InjectionNodes.InjectionNode;
 import org.spongepowered.asm.mixin.injection.struct.Target;
 import org.spongepowered.asm.mixin.injection.struct.Target.Extension;
 import org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException;
 import org.spongepowered.asm.util.Bytecode;
+
+import java.util.Arrays;
 
 /**
  * A bytecode injector which allows a single argument of a chosen method call to
@@ -78,28 +81,33 @@ public class ModifyArgsInjector extends InvokeInjector {
     @Override
     protected void injectAtInvoke(Target target, InjectionNode node) {
         MethodInsnNode targetMethod = (MethodInsnNode)node.getCurrentTarget();
-        
-        Type[] args = Type.getArgumentTypes(targetMethod.desc);
-        if (args.length == 0) {
+
+        Type[] originalArgs = InvokeUtil.getOriginalArgs(node);
+        Type[] currentArgs = InvokeUtil.getCurrentArgs(node);
+        if (originalArgs.length == 0) {
             throw new InvalidInjectionException(this.info, "@ModifyArgs injector " + this + " targets a method invocation "
                     + targetMethod.name + targetMethod.desc + " with no arguments!");
         }
-        
-        String clArgs = this.argsClassGenerator.getArgsClass(targetMethod.desc, this.info.getMixin().getMixin()).getName();
+
+        String originalDesc = Type.getMethodDescriptor(Type.VOID_TYPE, originalArgs);
+        String clArgs = this.argsClassGenerator.getArgsClass(originalDesc, this.info.getMixin().getMixin()).getName();
         boolean withArgs = this.verifyTarget(target);
 
         InsnList insns = new InsnList();
         Extension extraStack = target.extendStack().add(1);
-        
-        this.packArgs(insns, clArgs, targetMethod);
-        
+
+        Type[] extraArgs = Arrays.copyOfRange(currentArgs, originalArgs.length, currentArgs.length);
+        int[] extraArgMap = this.storeArgs(target, extraArgs, insns, 0);
+        this.packArgs(insns, clArgs, originalDesc);
+
         if (withArgs) {
             extraStack.add(target.arguments);
             Bytecode.loadArgs(target.arguments, insns, target.isStatic ? 0 : 1);
         }
         
         this.invokeHandler(insns);
-        this.unpackArgs(insns, clArgs, args);
+        this.unpackArgs(insns, clArgs, originalArgs);
+        this.pushArgs(extraArgs, insns, extraArgMap, 0, extraArgs.length);
         
         extraStack.apply();
         target.insns.insertBefore(targetMethod, insns);
@@ -121,8 +129,8 @@ public class ModifyArgsInjector extends InvokeInjector {
         return false;
     }
 
-    private void packArgs(InsnList insns, String clArgs, MethodInsnNode targetMethod) {
-        String factoryDesc = Bytecode.changeDescriptorReturnType(targetMethod.desc, "L" + clArgs + ";");
+    private void packArgs(InsnList insns, String clArgs, String targetDesc) {
+        String factoryDesc = Bytecode.changeDescriptorReturnType(targetDesc, "L" + clArgs + ";");
         insns.add(new MethodInsnNode(Opcodes.INVOKESTATIC, clArgs, "of", factoryDesc, false));
         insns.add(new InsnNode(Opcodes.DUP));
         

--- a/src/main/java/org/spongepowered/asm/mixin/injection/invoke/RedirectInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/invoke/RedirectInjector.java
@@ -103,7 +103,7 @@ public class RedirectInjector extends InvokeInjector {
     /**
      * Meta decoration object for redirector target nodes
      */
-    class Meta {
+    public class Meta {
         
         public static final String KEY = "redirector";
 

--- a/src/main/java/org/spongepowered/asm/mixin/injection/invoke/util/InvokeUtil.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/invoke/util/InvokeUtil.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin.injection.invoke.util;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.spongepowered.asm.mixin.injection.invoke.RedirectInjector;
+import org.spongepowered.asm.mixin.injection.struct.InjectionNodes.InjectionNode;
+
+import java.util.Arrays;
+
+public class InvokeUtil {
+    public static Type[] getOriginalArgs(InjectionNode node) {
+        return Type.getArgumentTypes(((MethodInsnNode) node.getOriginalTarget()).desc);
+    }
+
+    public static Type[] getCurrentArgs(InjectionNode node) {
+        MethodInsnNode methodNode = (MethodInsnNode) node.getCurrentTarget();
+        Type[] currentArgs = Type.getArgumentTypes(methodNode.desc);
+        if (node.isReplaced() && node.hasDecoration(RedirectInjector.Meta.KEY) && methodNode.getOpcode() != Opcodes.INVOKESTATIC) {
+            // A non-static redirect handler method will have an extra arg at the start that we don't care about.
+            return Arrays.copyOfRange(currentArgs, 1, currentArgs.length);
+        }
+        return currentArgs;
+    }
+}


### PR DESCRIPTION
Currently `@ModifyArg(s)` doesn't check whether the targeted call has been redirected and as a result there are errors with mismatching indices / invalid implicit discriminators.
Tested with AOF7, doesn't break anything.
Supersedes #114
Fixes https://github.com/SpongePowered/Mixin/issues/544