### PR TITLE
Fix: Properly extend the stack in `CallbackInjector`.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInjector.java
@@ -212,10 +212,7 @@ public class CallbackInjector extends Injector {
             this.invoke = target.extendStack();
             this.ctor = target.extendStack();
 
-            this.invoke.add(target.arguments.length);
-            if (this.canCaptureLocals) {
-                this.invoke.add(this.localTypes.length - this.frameSize);
-            }
+            this.invoke.add().add(handlerArgs);
 
             //If the handler doesn't captureArgs, the CallbackInfo(Returnable) will be the first LVT slot, otherwise it will be at the target's frameSize
             int callbackInfoSlot = handlerArgs.length == 1 ? Bytecode.isStatic(handler) ? 0 : 1 : frameSize;


### PR DESCRIPTION
The old logic misses the receiver and the CallbackInfo, and does not correctly handle double-size types.
This fixes occasional local capture failures due to ASM's Analyzer bailing out. Notably there is one such case in AOF7 that this fixes.