### PR TITLE
Allow adding configurations from arbitrary streams

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/Config.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/Config.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.asm.mixin.transformer;
 
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -176,6 +177,10 @@ public class Config {
         }
         
         return config;
+    }
+
+    public static Config create(String configName, InputStream resource) {
+        return MixinConfig.create(configName, resource, MixinEnvironment.getDefaultEnvironment());
     }
 
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
@@ -1273,31 +1273,42 @@ final class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
             return (this.priority < other.priority) ? -1 : 1;
         }
     }
-    
+
     /**
      * Factory method, creates a new mixin configuration bundle from the
      * specified configFile, which must be accessible on the classpath
-     * 
+     *
      * @param configFile configuration file to load
      * @param outer fallback environment
      * @return new Config
      */
     static Config create(String configFile, MixinEnvironment outer) {
+        return create(configFile, MixinService.getService().getResourceAsStream(configFile), outer);
+    }
+    
+    /**
+     * Factory method, creates a new mixin configuration bundle from the
+     * specified configName and resource.
+     * 
+     * @param configName configuration name
+     * @param resource configuration to load
+     * @param outer fallback environment
+     * @return new Config
+     */
+    static Config create(String configName, InputStream resource, MixinEnvironment outer) {
         try {
-            IMixinService service = MixinService.getService();
-            InputStream resource = service.getResourceAsStream(configFile);
             if (resource == null) {
-                throw new IllegalArgumentException(String.format("The specified resource '%s' was invalid or could not be read", configFile));
+                throw new IllegalArgumentException(String.format("The specified resource '%s' was invalid or could not be read", configName));
             }
             MixinConfig config = new Gson().fromJson(new InputStreamReader(resource), MixinConfig.class);
-            if (config.onLoad(service, configFile, outer)) {
+            if (config.onLoad(MixinService.getService(), configName, outer)) {
                 return config.getHandle();
             }
             return null;
         } catch (IllegalArgumentException ex) {
             throw ex;
         } catch (Exception ex) {
-            throw new IllegalArgumentException(String.format("The specified resource '%s' was invalid or could not be read", configFile), ex);
+            throw new IllegalArgumentException(String.format("The specified resource '%s' was invalid or could not be read", configName), ex);
         }
     }
 


### PR DESCRIPTION
This allows registering not on the classpath, for example in-memory configs with `ByteArrayInputStream` or in the proposed cache directory https://github.com/FabricMC/fabric-loader/pull/906.

I also updated the `registeredConfigs.contains` check to mirror the `FabricMixinBootstrap` one.