### PR TITLE
Fix: Reset Unique field counters on Mixin application.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MethodMapper.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MethodMapper.java
@@ -76,6 +76,14 @@ class MethodMapper {
     public ClassInfo getClassInfo() {
         return this.info;
     }
+
+    /**
+     * Resets the counters to prepare for application, which can happen multiple times due to hotswap.
+     */
+    public void reset() {
+        this.nextUniqueMethodIndex = 0;
+        this.nextUniqueFieldIndex = 0;
+    }
     
     /**
      * Conforms an injector handler method

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/TargetClassContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/TargetClassContext.java
@@ -407,9 +407,10 @@ final class TargetClassContext extends ClassContext implements ITargetClassConte
     }
     
     /**
-     * Run extensions before apply
+     * Run extensions before apply and clean up any global state in case this is a hotswap
      */
     private void preApply() {
+        this.getClassInfo().getMethodMapper().reset();
         this.extensions.preApply(this);
     }
 


### PR DESCRIPTION
They previously caused hotswaps to fail due to the number increasing on each application.