### PR TITLE
Modify Modlauncher bytecode provider class parser flags

### DIFF
--- a/src/modlauncher/java/org/spongepowered/asm/launch/MixinLaunchPluginLegacy.java
+++ b/src/modlauncher/java/org/spongepowered/asm/launch/MixinLaunchPluginLegacy.java
@@ -235,7 +235,7 @@ public class MixinLaunchPluginLegacy implements ILaunchPluginService, IClassByte
         if (classBytes != null && classBytes.length != 0) {
             ClassNode classNode = new ClassNode();
             ClassReader classReader = new MixinClassReader(classBytes, canonicalName);
-            classReader.accept(classNode, ClassReader.EXPAND_FRAMES);
+            classReader.accept(classNode, 0);
             return classNode;
         }
         


### PR DESCRIPTION
Changes the flags used to read `ClassNode`s in Mixin's modlauncher bytecode provider class, `MixinLaunchPluginLegacy`, to use `0` instead of `ClassReader.EXPAND_FRAMES`. This is to ensure the correctness of local variable analysis, as well as to achieve parity with Fabric's flag usage (which is currently the opposite of modlauncher's settings).

https://github.com/FabricMC/Mixin/blob/a2091792e8bb9b0951cef82528da9127f2c3b451/src/modlauncher/java/org/spongepowered/asm/launch/MixinLaunchPluginLegacy.java#L238

For a complete description of the issue, please see neoforged/NeoForge#768.