### PR TITLE
ModLauncher Integration: Remove reliance on Package Specification Version

### DIFF
--- a/src/modlauncher/java/org/spongepowered/asm/service/modlauncher/MixinServiceModLauncher.java
+++ b/src/modlauncher/java/org/spongepowered/asm/service/modlauncher/MixinServiceModLauncher.java
@@ -27,7 +27,10 @@ package org.spongepowered.asm.service.modlauncher;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.util.Collection;
+import java.util.Optional;
 
+import cpw.mods.modlauncher.api.IEnvironment;
+import cpw.mods.modlauncher.api.TypesafeMap;
 import org.spongepowered.asm.launch.IClassProcessor;
 import org.spongepowered.asm.launch.platform.container.ContainerHandleModLauncher;
 import org.spongepowered.asm.logging.ILogger;
@@ -47,6 +50,7 @@ import com.google.common.collect.ImmutableList;
 
 import cpw.mods.modlauncher.Launcher;
 import cpw.mods.modlauncher.api.ITransformationService;
+import org.spongepowered.asm.util.VersionNumber;
 
 /**
  * Mixin service for ModLauncher
@@ -56,7 +60,7 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
     /**
      * Specification version to check for at startup
      */
-    private static final String MODLAUNCHER_4_SPECIFICATION_VERSION = "4.0";
+    private static final VersionNumber MODLAUNCHER_4_SPECIFICATION_VERSION = VersionNumber.parse("4.0");
     
     /**
      * Specification version for ModLauncher versions &gt;= 9.0.4, yes this is
@@ -65,8 +69,8 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
      * version 5.0 for example, and ML7 and ML8 both had specification version
      * 7.0).
      */
-    private static final String MODLAUNCHER_9_SPECIFICATION_VERSION = "8.0";
-    
+    private static final VersionNumber MODLAUNCHER_9_SPECIFICATION_VERSION = VersionNumber.parse("8.0");
+
     private static final String CONTAINER_PACKAGE = MixinServiceAbstract.LAUNCH_PACKAGE + "platform.container.";
     private static final String MODLAUNCHER_4_ROOT_CONTAINER_CLASS = MixinServiceModLauncher.CONTAINER_PACKAGE + "ContainerHandleModLauncher";
     private static final String MODLAUNCHER_9_ROOT_CONTAINER_CLASS = MixinServiceModLauncher.CONTAINER_PACKAGE + "ContainerHandleModLauncherEx";
@@ -117,15 +121,15 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
     private CompatibilityLevel minCompatibilityLevel = CompatibilityLevel.JAVA_8;
     
     public MixinServiceModLauncher() {
-        final Package pkg = ITransformationService.class.getPackage();
-        if (pkg.isCompatibleWith(MixinServiceModLauncher.MODLAUNCHER_9_SPECIFICATION_VERSION)) {
+        VersionNumber apiVersion = getModLauncherApiVersion();
+        if (apiVersion.compareTo(MODLAUNCHER_9_SPECIFICATION_VERSION) >= 0) {
             this.createRootContainer(MixinServiceModLauncher.MODLAUNCHER_9_ROOT_CONTAINER_CLASS);
             this.minCompatibilityLevel = CompatibilityLevel.JAVA_16;
         } else {
             this.createRootContainer(MixinServiceModLauncher.MODLAUNCHER_4_ROOT_CONTAINER_CLASS);
         }
     }
-    
+
     /**
      * Begin init
      * 
@@ -200,9 +204,8 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
     @Override
     public boolean isValid() {
         try {
-            Launcher.INSTANCE.hashCode();
-            final Package pkg = ITransformationService.class.getPackage();
-            if (!pkg.isCompatibleWith(MixinServiceModLauncher.MODLAUNCHER_4_SPECIFICATION_VERSION)) {
+            VersionNumber apiVersion = getModLauncherApiVersion();
+            if (apiVersion.compareTo(MixinServiceModLauncher.MODLAUNCHER_4_SPECIFICATION_VERSION) < 0) {
                 return false;
             }
         } catch (Throwable th) {
@@ -309,6 +312,22 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
             this.getTransformationHandler(),
             (IClassProcessor)this.getClassTracker()
         );
+    }
+
+    private static VersionNumber getModLauncherApiVersion() {
+        Optional<String> version = Optional.empty();
+        try {
+            TypesafeMap.Key<String> versionProperty = IEnvironment.Keys.MLSPEC_VERSION.get();
+            version = Launcher.INSTANCE.environment().getProperty(versionProperty);
+        } catch (Exception ignored) {
+        }
+
+        // Fall back to the package information (this is not present when loaded as a module)
+        if (!version.isPresent()) {
+            version = Optional.ofNullable(ITransformationService.class.getPackage().getSpecificationVersion());
+        }
+
+        return version.map(VersionNumber::parse).orElse(VersionNumber.NONE);
     }
 
 }


### PR DESCRIPTION
This is a commit that was already merged upstream and is part of 0.8.6:
https://github.com/SpongePowered/Mixin/commit/a40c96a63f4d000fa518e65ae7f7093c06c4228d

Rely on the ML-Specification version present in the ModLauncher environment rather than on the Package specification version, since that version is unavailable in two scenarios: 1) ML loaded as a JPMS module and 2) ML added to the classpath using a folder rather than JAR-file.