### PR TITLE
Fix: Properly extend the stack in `ModifyArgInjector`.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/invoke/ModifyArgInjector.java
@@ -123,7 +123,12 @@ public class ModifyArgInjector extends InvokeInjector {
         }
         
         target.insns.insertBefore(methodNode, insns);
-        target.extendStack().set(2 - (extraLocals.get() - 1)).apply();
+        Extension extraStack = target.extendStack();
+        if (!isStatic) {
+            extraStack.add();
+        }
+        extraStack.add(methodArgs);
+        extraStack.apply();
         extraLocals.apply();
     }
 


### PR DESCRIPTION
The old logic doesn't really make any sense and the calculated extension usually ended up being negative. Instead, we just make room for our possible receiver and all of our args.