### PR TITLE
Fix apply failure when mixin method calls `clone` on an array

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -600,8 +600,13 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
         } else if (this.detachedSuper || this.inheritsFromMixin) {
             if (methodRef.getOpcode() == Opcodes.INVOKESPECIAL) {
                 this.updateStaticBinding(method, methodRef);
-            } else if (methodRef.getOpcode() == Opcodes.INVOKEVIRTUAL && ClassInfo.forName(methodRef.getOwner()).isMixin()) {
-                this.updateDynamicBinding(method, methodRef);
+            } else if (methodRef.getOpcode() == Opcodes.INVOKEVIRTUAL) {
+                // ignore method calls on arrays (i.e. #clone)
+                if (!methodRef.getOwner().startsWith("[")) {
+                    if (ClassInfo.forName(methodRef.getOwner()).isMixin()) {
+                        this.updateDynamicBinding(method, methodRef);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Any Mixin method calling clone on an array will trigger the bug.

Stacktrace:
```
Caused by: java.lang.NullPointerException: Cannot invoke "org.spongepowered.asm.mixin.transformer.ClassInfo.isMixin()" because the return value of "org.spongepowered.asm.mixin.transformer.ClassInfo.forName(String)" is null
    at org.spongepowered.asm.mixin.transformer.MixinTargetContext.transformMethodRef(MixinTargetContext.java:592)
    at org.spongepowered.asm.mixin.transformer.MixinTargetContext.transformMethod(MixinTargetContext.java:484)
    ... 22 more
```
Workaround:
```java
public final class MixinWorkarounds {

    public static long[] clone(final long[] values) {
        return values.clone();
    }

}
```