### PR TITLE
Fix: Do not re-parent calls to interface super methods.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -871,6 +871,10 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
      * @param methodRef Unbound reference to the method
      */
     private void updateStaticBinding(MethodNode method, MemberRef methodRef) {
+        if (!methodRef.getOwner().equals(this.classNode.superName)) {
+            // Must be to an interface, no need to re-parent.
+            return;
+        }
         this.updateBinding(method, methodRef, Traversal.SUPER);
     }
 


### PR DESCRIPTION
The existing logic is wrong, and they will always be valid as-is because any superinterfaces will be merged onto the target class.

Closes #146