### PR TITLE
Fix enum MixinEnvironment.Option parsing always using the default

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
+++ b/src/main/java/org/spongepowered/asm/mixin/MixinEnvironment.java
@@ -625,11 +625,10 @@ public final class MixinEnvironment implements ITokenProvider {
                     ? System.getProperty(this.property, this.defaultValue) : this.defaultValue;
         }
 
-        @SuppressWarnings("unchecked")
         <E extends Enum<E>> E getEnumValue(E defaultValue) {
             String value = System.getProperty(this.property, defaultValue.name());
             try {
-                return (E)Enum.valueOf(defaultValue.getDeclaringClass(), value.toUpperCase(Locale.ROOT));
+                return Enum.valueOf(defaultValue.getDeclaringClass(), value.toUpperCase(Locale.ROOT));
             } catch (IllegalArgumentException ex) {
                 return defaultValue;
             }


### PR DESCRIPTION
The previous implementation always throws since it passes the wrong class to Enum.valueOf (e.g. `CompatibilityLevel$2` instead of `CompatibilityLevel`)