### PR TITLE
Analyze jdk classes through reflection instead of asm

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.asm.mixin.transformer;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -905,6 +907,59 @@ public final class ClassInfo {
         } finally {
             timer.end();
         }
+    }
+
+    private ClassInfo(Class<?> cls) {
+        this.name = getName(cls);
+        this.superName = cls.getSuperclass() != null ? getName(cls.getSuperclass()) : ClassInfo.JAVA_LANG_OBJECT;
+        this.initialisers = new HashSet<Method>();
+        this.methods = new HashSet<Method>();
+        this.fields = new HashSet<Field>();
+        this.isInterface = cls.isInterface();
+        Class<?>[] interfaces = cls.getInterfaces();
+        this.interfaces = new HashSet<String>(interfaces.length);
+        this.isMixin = false;
+        this.mixin = null;
+        this.mixins = Collections.emptySet();
+
+        for (Class<?> iface : interfaces) {
+            this.interfaces.add(getName(iface));
+        }
+
+        for (Constructor<?> ctor : cls.getDeclaredConstructors()) {
+            if ((ctor.getModifiers() & (Modifier.PROTECTED | Modifier.PUBLIC)) == 0) {
+                continue;
+            }
+
+            this.initialisers.add(new Method(ctor.getName(), org.objectweb.asm.Type.getConstructorDescriptor(ctor), ctor.getModifiers()));
+        }
+
+        for (java.lang.reflect.Method method : cls.getDeclaredMethods()) {
+            if ((method.getModifiers() & (Modifier.PROTECTED | Modifier.PUBLIC)) == 0) {
+                continue;
+            }
+
+            this.methods.add(new Method(method.getName(), org.objectweb.asm.Type.getMethodDescriptor(method), method.getModifiers()));
+        }
+
+        for (java.lang.reflect.Field field : cls.getDeclaredFields()) {
+            if ((field.getModifiers() & (Modifier.PROTECTED | Modifier.PUBLIC)) == 0) {
+                continue;
+            }
+
+            this.fields.add(new Field(field.getName(), org.objectweb.asm.Type.getDescriptor(field.getType()), field.getModifiers()));
+        }
+
+        this.isProbablyStatic = true;
+        this.methodMapper = null;
+
+        this.access = cls.getModifiers();
+        this.isInner = false;
+        this.outerName = null;
+    }
+
+    private static String getName(Class<?> cls) {
+        return cls.getName().replace('.', '/');
     }
 
     void addInterface(String iface) {
@@ -2025,9 +2080,13 @@ public final class ClassInfo {
         ClassInfo info = ClassInfo.cache.get(className);
         if (info == null) {
             try {
-                int flags = MixinEnvironment.getCurrentEnvironment().getOption(Option.CLASSREADER_EXPAND_FRAMES) ? ClassReader.EXPAND_FRAMES : 0;
-                ClassNode classNode = MixinService.getService().getBytecodeProvider().getClassNode(className, true, flags);
-                info = new ClassInfo(classNode);
+                if (className.startsWith("java/")) { // this would ideally check the platform class loader for other jdk classes, but needs extra api to do so
+                    info = new ClassInfo(Class.forName(className.replace('/', '.'), false, ClassInfo.class.getClassLoader()));
+                } else {
+                    int flags = MixinEnvironment.getCurrentEnvironment().getOption(Option.CLASSREADER_EXPAND_FRAMES) ? ClassReader.EXPAND_FRAMES : 0;
+                    ClassNode classNode = MixinService.getService().getBytecodeProvider().getClassNode(className, true, flags);
+                    info = new ClassInfo(classNode);
+                }
             } catch (Exception ex) {
                 ClassInfo.logger.catching(Level.TRACE, ex);
                 ClassInfo.logger.warn("Error loading class: {} ({}: {})", className, ex.getClass().getName(), ex.getMessage());

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
@@ -950,12 +950,12 @@ public final class ClassInfo {
             this.fields.add(new Field(field.getName(), org.objectweb.asm.Type.getDescriptor(field.getType()), field.getModifiers()));
         }
 
-        this.isProbablyStatic = true;
+        this.isProbablyStatic = cls.getEnclosingClass() == null || Modifier.isStatic(cls.getModifiers());
         this.methodMapper = null;
 
         this.access = cls.getModifiers();
-        this.isInner = false;
-        this.outerName = null;
+        this.isInner = cls.getEnclosingClass() != null;
+        this.outerName = cls.getDeclaringClass() != null ? getName(cls.getDeclaringClass()) : null;
     }
 
     private static String getName(Class<?> cls) {


### PR DESCRIPTION
This already seems to be enough to make MC 1.21.1 run with Java 23, Fabric API and an ASM version incompatible with the active JDK.

It doesn't look like Mixin needs any of the non-populated data, I probably already fill in more than necessary. It is assumed that mixins can't target jdk classes, but Mixin doesn't seem to give good early errors for this, I think it'd end up silently ignoring those targets as they wouldn't go through Knot in the first place. Improving that is out of scope for this change.