### PR TITLE
Allow `@Desc` to match field instructions

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/dynamic/DynamicSelectorDesc.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/dynamic/DynamicSelectorDesc.java
@@ -503,7 +503,7 @@ public class DynamicSelectorDesc implements ITargetSelectorDynamic, ITargetSelec
         if (node == null || this.disabled) {
             return MatchResult.NONE;
         } else if (node.isField()) {
-            return this.matches(node.getOwner(), node.getName(), node.getDesc(), this.returnType.getInternalName());
+            return this.matches(node.getOwner(), node.getName(), node.getDesc(), this.returnType.getDescriptor());
         } else {
             return this.matches(node.getOwner(), node.getName(), node.getDesc(), this.methodDesc);
         }


### PR DESCRIPTION
Related regression test: <https://github.com/stianloader/Micromixin/commit/87b91ec8009536e4f4956c5694d824bb73ccc3a5>
`InjectionPointTest.FieldInjectDescInt` passes correctly, but `InjectionPointTest.FieldInjectDescObject` fails. Culprit seems to be https://github.com/FabricMC/Mixin/blob/c516fb7d3f18eea1eed0abdf9d73324d5c7d2a15/src/main/java/org/spongepowered/asm/mixin/injection/selectors/dynamic/DynamicSelectorDesc.java#L513 - `compareWithDesc` being `java/lang/Object` while `desc` is `Ljava/lang/Object;`. This patch rectifies the input `compareWithDesc` argument to make use of the descriptor string format instead of using the internal name.

Does not affect fields with a primitive type.