### PR TITLE
Don't initialize classes in mixin audit

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
@@ -251,7 +251,7 @@ class MixinProcessor {
         for (String target : unhandled) {
             try {
                 auditLogger.info("Force-loading class {}", target);
-                this.service.getClassProvider().findClass(target, true);
+                this.service.getClassProvider().findClass(target, false);
             } catch (ClassNotFoundException ex) {
                 auditLogger.error("Could not force-load " + target, ex);
             }


### PR DESCRIPTION
There is no reason to initialize (call `<clinit>`) on classes for mixin audit. Doing this makes it harder to use mixin audit in unit tests, forcing you to pre-load various subcomponents of the game, and over time there is an increasing amount of them required. More generally it disrupts class loading order, that poorly designed programs may rely on.

Stock mixin PR: https://github.com/SpongePowered/Mixin/pull/703