### PR TITLE
Allow querying whether classes could be transformed by mixin

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/IMixinTransformer.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/IMixinTransformer.java
@@ -101,6 +101,15 @@ public interface IMixinTransformer {
      * @return true if the class was transformed
      */
     public abstract boolean transformClass(MixinEnvironment environment, String name, ClassNode classNode);
+
+    /**
+     * Determines whether mixin could transform the provided class, without actually running the transformation
+     * 
+     * @param environment Current environment
+     * @param name Class transformed name
+     * @return true if the class could be transformed
+     */
+    public abstract boolean couldTransformClass(MixinEnvironment environment, String name);
     
     /**
      * Generate the specified mixin-synthetic class

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessor.java
@@ -25,7 +25,9 @@
 package org.spongepowered.asm.mixin.transformer;
 
 import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.logging.ILogger;
 import org.spongepowered.asm.mixin.transformer.MixinConfig.IListener;
+import org.spongepowered.asm.service.MixinService;
 
 /**
  * Coprocessors are parts of the mixin pipeline which aren't involved in
@@ -153,14 +155,19 @@ abstract class MixinCoprocessor implements IListener {
         return ProcessResult.NONE;
     }
 
+    private static final ILogger logger = MixinService.getService().getLogger("mixin");
+
     /**
-     * Determine ahead-of-time whether a given class could be transformed by processing by this coprocessor.
+     * Determine ahead-of-time whether a given class could be transformed ({@link ProcessResult#TRANSFORMED},
+     * {@link ProcessResult#PASSTHROUGH_TRANSFORMED}, or modification in
+     * {@link MixinCoprocessor#postProcess(String, ClassNode)}) by processing by this coprocessor.
      * 
      * @param className Name of the target class
      * @return true if the coprocessor might transform the class when processed
      */
     public boolean processingCouldTransform(String className) {
-        return false;
+        logger.error("MixinCoprocessor {} does not implement processingCouldTransform, which may lead to unnecessary transformation of class {}", getName(), className);
+        return true;
     } 
 
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessor.java
@@ -154,6 +154,16 @@ abstract class MixinCoprocessor implements IListener {
     }
 
     /**
+     * Determine ahead-of-time whether a given class could be transformed by processing by this coprocessor.
+     * 
+     * @param className Name of the target class
+     * @return true if the coprocessor might transform the class when processed
+     */
+    public boolean processingCouldTransform(String className) {
+        return false;
+    } 
+
+    /**
      * Perform postprocessing actions on the supplied class. This is called for
      * all classes. For passthrough classes and classes which are not mixin 
      * targets this is called immediately after {@link #process} is completed

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessorAccessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessorAccessor.java
@@ -126,6 +126,11 @@ class MixinCoprocessorAccessor extends MixinCoprocessor {
         return ProcessResult.PASSTHROUGH_TRANSFORMED;
     }
 
+    @Override
+    public boolean processingCouldTransform(String className) {
+        return MixinEnvironment.getCompatibilityLevel().supports(LanguageFeatures.METHODS_IN_INTERFACES) && this.accessorMixins.containsKey(className);
+    }
+
     private Method getAccessorMethod(MixinInfo mixin, MethodNode methodNode, ClassInfo targetClass) throws MixinTransformerError {
         Method method = mixin.getClassInfo().findMethod(methodNode, ClassInfo.INCLUDE_ALL);
         

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessorNestHost.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessorNestHost.java
@@ -105,4 +105,8 @@ class MixinCoprocessorNestHost extends MixinCoprocessor {
         return true;
     }
 
+    @Override
+    public boolean processingCouldTransform(String className) {
+        return this.nestHosts.containsKey(className);
+    }
 }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessorPassthrough.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessorPassthrough.java
@@ -63,5 +63,4 @@ class MixinCoprocessorPassthrough extends MixinCoprocessor {
     ProcessResult process(String className, ClassNode classNode) {
         return this.loadable.contains(className) ? ProcessResult.PASSTHROUGH_NONE : ProcessResult.NONE;
     }
-
 }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessorPassthrough.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessorPassthrough.java
@@ -63,4 +63,9 @@ class MixinCoprocessorPassthrough extends MixinCoprocessor {
     ProcessResult process(String className, ClassNode classNode) {
         return this.loadable.contains(className) ? ProcessResult.PASSTHROUGH_NONE : ProcessResult.NONE;
     }
+
+    @Override
+    public boolean processingCouldTransform(String className) {
+        return false;
+    }
 }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessorSyntheticInner.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessorSyntheticInner.java
@@ -68,6 +68,11 @@ class MixinCoprocessorSyntheticInner extends MixinCoprocessor {
         this.syntheticInnerClasses.add(className);
     }
 
+    @Override
+    public boolean processingCouldTransform(String className) {
+        return this.syntheticInnerClasses.contains(className);
+    }
+
     /**
      * "Pass through" a synthetic inner class. Transforms package-private
      * members in the class into public so that they are accessible from their

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessors.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinCoprocessors.java
@@ -68,6 +68,21 @@ class MixinCoprocessors extends ArrayList<MixinCoprocessor> {
     }
 
     /**
+     * Determine ahead-of-time whether a given class could be transformed by any registered coprocessor.
+     * 
+     * @param className
+     * @return
+     */
+    public boolean processingCouldTransform(String className) {
+        for (MixinCoprocessor coprocessor : this) {
+            if (coprocessor.processingCouldTransform(className)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Perform postprocessing actions on the supplied class using all registered
      * coprocessors.
      * 

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
@@ -397,7 +397,13 @@ class MixinProcessor {
         return transformed;
     }
 
-    synchronized boolean couldApplyMixins(String name) {
+    synchronized boolean couldApplyMixins(MixinEnvironment environment, String name) {
+        try {
+            this.checkSelect(environment);
+        } catch (Exception ex) {
+            throw new MixinException(ex);
+        }
+
         if (name == null || this.errorState) {
             return false;
         }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
@@ -398,14 +398,14 @@ class MixinProcessor {
     }
 
     synchronized boolean couldApplyMixins(MixinEnvironment environment, String name) {
+        if (name == null || this.errorState) {
+            return false;
+        }
+
         try {
             this.checkSelect(environment);
         } catch (Exception ex) {
             throw new MixinException(ex);
-        }
-
-        if (name == null || this.errorState) {
-            return false;
         }
 
         if (this.coprocessors.processingCouldTransform(name)) {

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformer.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformer.java
@@ -259,7 +259,7 @@ final class MixinTransformer extends TreeTransformer implements IMixinTransforme
      */
     @Override
     public synchronized boolean couldTransformClass(MixinEnvironment environment, String name) {
-        return this.processor.couldApplyMixins(name);
+        return this.processor.couldApplyMixins(environment, name);
     }
 
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformer.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformer.java
@@ -249,7 +249,19 @@ final class MixinTransformer extends TreeTransformer implements IMixinTransforme
     public synchronized boolean transformClass(MixinEnvironment environment, String name, ClassNode classNode) {
         return this.processor.applyMixins(environment, name, classNode);
     }
-    
+
+    /**
+     * Determines whether mixin could transform the provided class, without actually running the transformation
+     *
+     * @param environment Current environment
+     * @param name Class transformed name
+     * @return true if the class could be transformed
+     */
+    @Override
+    public synchronized boolean couldTransformClass(MixinEnvironment environment, String name) {
+        return this.processor.couldApplyMixins(name);
+    }
+
     /**
      * Generate the specified mixin-synthetic class
      * 


### PR DESCRIPTION
This exposes an API that a system using mixin (such as neoforge; see https://github.com/neoforged/FancyModLoader/pull/319) may use to ask mixin whether a given class should be passed to it for transformation. This addresses a similar issue to https://github.com/FabricMC/Mixin/pull/164, but instead of passing mixin class bytes and having those be lazily transformed to a `ClassNode`, it allows for querying ahead-of-time without the class bytes; this is necessary in a neoforge context given how the `ILaunchPluginService` system there works, where the parsing-to-ClassNode happens there, before being fed to any number of transformers, only if some plugin (like mixin) requests that the class be transformed ahead of time, from it's name.

This implementation prioritizes not giving false negatives for transformation; thus, for instance, the default implementation of `MixinCoprocessor#processingCouldTransform` always returns `true` so if by chance someone has hackily inserted a custom coprocessor, behaviour should not change. (That said, it also logs a message, at LlamaLad7's suggestion).