### PR TITLE
Add module version to compiled module-info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -343,6 +343,7 @@ project.sourceSets.each { set -> {
 
 compileModularityJava {
     inputs.files(modularityInputs)
+    options.javaModuleVersion = project.version as String
     doFirst {
         options.compilerArgs = [
             '--module-path', classpath.asPath,


### PR DESCRIPTION
We are attempting to make use of compat-level annotations for mixin configs in neoforge (see https://github.com/neoforged/FancyModLoader/pull/339) but with how we are structuring this, need the currently-running fabric mixin version at runtime to determine the maximum mixin version a mod should be able to request the equivalent compat to. We cannot use `Package#getImplementationVersion` to get this in all cases, because in a neo context, mixin may be running as a module and packages in modules do not have spec/impl versions attached. An easy solution is to attach the version to the module-info such that it can be retrieved from the module at runtime.