### PR TITLE
Close resource streams for mixin configs.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.asm.mixin.transformer;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
@@ -1389,8 +1388,8 @@ final class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
      * @return new Config
      */
     static Config create(String configFile, MixinEnvironment outer, IMixinConfigSource source) {
-        IMixinService service = MixinService.getService();
         try {
+            IMixinService service = MixinService.getService();
             InputStream resource = service.getResourceAsStream(configFile);
             if (resource == null) {
                 throw new IllegalArgumentException(String.format("The specified resource '%s' was invalid or could not be read", configFile));


### PR DESCRIPTION
Currently, Mixin opens streams for mixin configs and then lets them disipate into aether once the mixin config is parsed. This P.R. closes the streams after the mixin config is parsed