### PR TITLE
Feature/enum extensions

### DIFF
--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerShadow.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerShadow.java
@@ -27,6 +27,7 @@ package org.spongepowered.tools.obfuscation;
 import java.util.Locale;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 
@@ -131,7 +132,12 @@ class AnnotatedMixinElementHandlerShadow extends AnnotatedMixinElementHandler {
         public AnnotatedElementShadowMethod(ExecutableElement element, AnnotationHandle annotation, boolean shouldRemap) {
             super(element, annotation, shouldRemap, Type.METHOD);
         }
-        
+
+        @Override
+        public boolean shouldRemap() {
+            return super.shouldRemap() && this.element.getKind() != ElementKind.CONSTRUCTOR;
+        }
+
         @Override
         public MappingMethod getMapping(TypeHandle owner, String name, String desc) {
             return owner.getMappingMethod(name, desc);

--- a/src/ap/java/org/spongepowered/tools/obfuscation/MixinObfuscationProcessor.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/MixinObfuscationProcessor.java
@@ -66,7 +66,7 @@ abstract class MixinObfuscationProcessor extends AbstractProcessor {
         this.mixins.onPassStarted();
         
         for (Element elem : roundEnv.getElementsAnnotatedWith(Mixin.class)) {
-            if (elem.getKind() == ElementKind.CLASS || elem.getKind() == ElementKind.INTERFACE) {
+            if (elem.getKind() == ElementKind.CLASS || elem.getKind() == ElementKind.INTERFACE || elem.getKind() == ElementKind.ENUM) {
                 this.mixins.registerMixin((TypeElement)elem);
             } else {
                 this.mixins.printMessage(MessageType.MIXIN_ON_INVALID_TYPE,

--- a/src/ap/java/org/spongepowered/tools/obfuscation/MixinObfuscationProcessorTargets.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/MixinObfuscationProcessorTargets.java
@@ -107,7 +107,7 @@ public class MixinObfuscationProcessorTargets extends MixinObfuscationProcessor 
             
             if (elem.getKind() == ElementKind.FIELD) {
                 this.mixins.registerShadow((TypeElement)parent, (VariableElement)elem, shadow);
-            } else if (elem.getKind() == ElementKind.METHOD) {
+            } else if (elem.getKind() == ElementKind.METHOD || elem.getKind() == ElementKind.CONSTRUCTOR) {
                 this.mixins.registerShadow((TypeElement)parent, (ExecutableElement)elem, shadow);
             } else {
                 this.mixins.printMessage(MessageType.SHADOW_ON_INVALID_ELEMENT, "Element is not a method or field",  elem);

--- a/src/ap/java/org/spongepowered/tools/obfuscation/mirror/TypeUtils.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/mirror/TypeUtils.java
@@ -24,17 +24,11 @@
  */
 package org.spongepowered.tools.obfuscation.mirror;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.Name;
-import javax.lang.model.element.PackageElement;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.TypeParameterElement;
-import javax.lang.model.element.VariableElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.IntersectionType;
@@ -255,11 +249,11 @@ public abstract class TypeUtils {
             ExecutableElement method = (ExecutableElement)element;
             StringBuilder desc = new StringBuilder().append("(");
             boolean extra = false;
-            for (VariableElement arg : method.getParameters()) {
+            for (TypeName arg : TypeUtils.getAllParameterTypes(method)) {
                 if (extra) {
                     desc.append(',');
                 }
-                desc.append(TypeUtils.getTypeName(arg.asType()));
+                desc.append(arg.name);
                 extra = true;
             }
             desc.append(')').append(TypeUtils.getTypeName(method.getReturnType()));
@@ -351,8 +345,8 @@ public abstract class TypeUtils {
         
         StringBuilder signature = new StringBuilder();
         
-        for (VariableElement var : method.getParameters()) {
-            signature.append(TypeUtils.getInternalName(var));
+        for (TypeName var : TypeUtils.getAllParameterTypes(method)) {
+            signature.append(var.descriptor);
         }
         
         String returnType = TypeUtils.getInternalName(method.getReturnType());
@@ -607,6 +601,35 @@ public abstract class TypeUtils {
         }
         
         return Visibility.PACKAGE;
+    }
+
+    private static List<TypeName> getAllParameterTypes(ExecutableElement element) {
+        List<TypeName> result = new ArrayList<>();
+
+        if (element.getKind() == ElementKind.CONSTRUCTOR && element.getEnclosingElement().getKind() == ElementKind.ENUM) {
+            // Account for the preceding String and int parameters
+            result.add(new TypeName("java.lang.String", "Ljava/lang/String;"));
+            result.add(new TypeName("int", "I"));
+        }
+
+        for (VariableElement param : element.getParameters()) {
+            result.add(new TypeName(param.asType()));
+        }
+        return result;
+    }
+
+    private static class TypeName {
+        final String name;
+        final String descriptor;
+
+        public TypeName(String name, String descriptor) {
+            this.name = name;
+            this.descriptor = descriptor;
+        }
+
+        public TypeName(TypeMirror type) {
+            this(TypeUtils.getTypeName(type), TypeUtils.getInternalName(type));
+        }
     }
     
 }

--- a/src/launchwrapper/java/org/spongepowered/asm/service/mojang/MixinServiceLaunchWrapper.java
+++ b/src/launchwrapper/java/org/spongepowered/asm/service/mojang/MixinServiceLaunchWrapper.java
@@ -51,14 +51,7 @@ import org.spongepowered.asm.logging.ILogger;
 import org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel;
 import org.spongepowered.asm.mixin.MixinEnvironment.Phase;
 import org.spongepowered.asm.mixin.throwables.MixinException;
-import org.spongepowered.asm.service.IClassBytecodeProvider;
-import org.spongepowered.asm.service.IClassProvider;
-import org.spongepowered.asm.service.IClassTracker;
-import org.spongepowered.asm.service.ILegacyClassTransformer;
-import org.spongepowered.asm.service.IMixinAuditTrail;
-import org.spongepowered.asm.service.ITransformer;
-import org.spongepowered.asm.service.ITransformerProvider;
-import org.spongepowered.asm.service.MixinServiceAbstract;
+import org.spongepowered.asm.service.*;
 import org.spongepowered.asm.transformers.MixinClassReader;
 import org.spongepowered.asm.util.Constants;
 import org.spongepowered.asm.util.Files;
@@ -298,7 +291,15 @@ public class MixinServiceLaunchWrapper extends MixinServiceAbstract implements I
     public IMixinAuditTrail getAuditTrail() {
         return null;
     }
-    
+
+    /* (non-Javadoc)
+     * @see org.spongepowered.asm.service.IMixinService#getFeatureValidator()
+     */
+    @Override
+    public IFeatureValidator getFeatureValidator() {
+        return IFeatureValidator.ALLOW_ALL;
+    }
+
     /* (non-Javadoc)
      * @see org.spongepowered.asm.service.IClassProvider#findClass(
      *      java.lang.String)

--- a/src/launchwrapper/java/org/spongepowered/asm/service/mojang/MixinServiceLaunchWrapper.java
+++ b/src/launchwrapper/java/org/spongepowered/asm/service/mojang/MixinServiceLaunchWrapper.java
@@ -301,6 +301,14 @@ public class MixinServiceLaunchWrapper extends MixinServiceAbstract implements I
     }
 
     /* (non-Javadoc)
+     * @see org.spongepowered.asm.service.IMixinService#getAdviceProvider()
+     */
+    @Override
+    public IAdviceProvider getAdviceProvider() {
+        return IAdviceProvider.GENERIC;
+    }
+
+    /* (non-Javadoc)
      * @see org.spongepowered.asm.service.IClassProvider#findClass(
      *      java.lang.String)
      */

--- a/src/main/java/org/spongepowered/asm/mixin/FabricUtil.java
+++ b/src/main/java/org/spongepowered/asm/mixin/FabricUtil.java
@@ -91,7 +91,7 @@ public final class FabricUtil {
         return getCompatibility(context.getMixin().getConfig());
     }
 
-    private static int getCompatibility(IMixinConfig config) {
+    public static int getCompatibility(IMixinConfig config) {
         return getDecoration(config, KEY_COMPATIBILITY, COMPATIBILITY_LATEST);
     }
 

--- a/src/main/java/org/spongepowered/asm/mixin/MixinIntrinsics.java
+++ b/src/main/java/org/spongepowered/asm/mixin/MixinIntrinsics.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin;
+
+/**
+ * Intrinsics for use in @Mixin classes.
+ */
+public final class MixinIntrinsics {
+    private MixinIntrinsics() {}
+
+    /**
+     * Only to be used in the initializers of enum extension constants. Returns the current constant's final ordinal.
+     */
+    public static int currentEnumOrdinal() {
+        throw new UnsupportedOperationException("This method is intrinsic and can only be used in initializers of enum extension constants");
+    }
+}

--- a/src/main/java/org/spongepowered/asm/mixin/Shadow.java
+++ b/src/main/java/org/spongepowered/asm/mixin/Shadow.java
@@ -35,7 +35,7 @@ import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
  * Used to indicate a Mixin class member which is acting as a placeholder for a
  * method or field in the target class 
  */
-@Target({ ElementType.METHOD, ElementType.FIELD })
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Shadow {
 

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
@@ -1085,6 +1085,13 @@ public final class ClassInfo {
     }
 
     /**
+     * Get whether this class has ACC_FINAL
+     */
+    public boolean isFinal() {
+        return (this.access & Opcodes.ACC_FINAL) != 0;
+    }
+
+    /**
      * Get whether this class is probably static (or is not an inner class)
      */
     public boolean isProbablyStatic() {
@@ -1103,6 +1110,14 @@ public final class ClassInfo {
      */
     public boolean isInterface() {
         return this.isInterface;
+    }
+
+    /**
+     * Get whether this is an enum or not
+     */
+    public boolean isEnum() {
+        // Match Class#isEnum
+        return (this.access & Opcodes.ACC_ENUM) != 0 && this.superName.equals("java/lang/Enum");
     }
 
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/EnumExtensionUtils.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/EnumExtensionUtils.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin.transformer;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
+
+final class EnumExtensionUtils {
+    private EnumExtensionUtils() {}
+
+    public static void checkForGotchas(MixinInfo mixin, ClassNode classNode) throws InvalidMixinException {
+        checkForOrdinalSwitch(mixin, classNode);
+    }
+
+    private static void checkForOrdinalSwitch(MixinInfo mixin, ClassNode classNode) {
+        for (MethodNode method : classNode.methods) {
+            for (AbstractInsnNode insn : method.instructions) {
+                if (isOrdinalCall(insn, mixin) && isSwitch(insn.getNext())) {
+                    Integer line = findLineNumber(insn);
+                    throw new InvalidMixinException(
+                            mixin,
+                            String.format(
+                                    "`ordinal` switch on enum extension type is not supported but was found on line %s."
+                                            + " Instead, switch on the target enum, e.g. `switch ((TargetEnum) (Object) ...)`",
+                                    line
+                            )
+                    );
+                }
+            }
+        }
+    }
+
+    private static boolean isOrdinalCall(AbstractInsnNode insn, MixinInfo mixin) {
+        if (insn.getOpcode() != Opcodes.INVOKEVIRTUAL) {
+            return false;
+        }
+        MethodInsnNode call = (MethodInsnNode) insn;
+        return call.owner.equals(mixin.getClassRef()) && call.name.equals("ordinal") && call.desc.equals("()I");
+    }
+
+    private static boolean isSwitch(AbstractInsnNode insn) {
+        return insn.getOpcode() == Opcodes.TABLESWITCH || insn.getOpcode() == Opcodes.LOOKUPSWITCH;
+    }
+
+    private static Integer findLineNumber(AbstractInsnNode insn) {
+        do {
+            if (insn instanceof LineNumberNode) {
+                return ((LineNumberNode) insn).line;
+            }
+            insn = insn.getPrevious();
+        } while (insn != null);
+
+        return null;
+    }
+}

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/EnumInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/EnumInfo.java
@@ -37,6 +37,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 final class EnumInfo implements Comparable<EnumInfo> {
+    // Attached by build-time frameworks like class-tweaker, we remove these entries in favour of our own
+    private static final String STUB_ENUM_CONSTANT_ATTRIBUTE = "org.spongepowered.asm.mixin.StubEnumConstant";
+
     private final ClassContext enumClass;
     private final ClassContext targetClass;
     private final String description;
@@ -74,7 +77,7 @@ final class EnumInfo implements Comparable<EnumInfo> {
     }
 
     /**
-     * Returns the fields whose type is the type of the enum
+     * Returns the fields whose type is the type of the enum, excluding stub constants
      */
     public List<FieldNode> getSelfTypedFields() {
         return this.selfTypedFields;
@@ -154,7 +157,7 @@ final class EnumInfo implements Comparable<EnumInfo> {
         String selfDesc = 'L' + this.targetClass.getClassRef() + ';';
         List<FieldNode> result = new ArrayList<>();
         for (FieldNode field : this.enumClass.getClassNode().fields) {
-            if (field.desc.equals(selfDesc)) {
+            if (field.desc.equals(selfDesc) && !isStubEnumConstant(field)) {
                 result.add(field);
             }
         }
@@ -185,6 +188,10 @@ final class EnumInfo implements Comparable<EnumInfo> {
             }
         }
         return false;
+    }
+
+    private static boolean isStubEnumConstant(FieldNode field) {
+        return field.attrs != null && field.attrs.stream().anyMatch(attr -> attr.type.equals(STUB_ENUM_CONSTANT_ATTRIBUTE));
     }
 
     private static AssumptionViolatedException assumptionViolated(String template, Object... args) {

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/EnumInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/EnumInfo.java
@@ -1,0 +1,199 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin.transformer;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
+import org.spongepowered.asm.util.Bytecode;
+import org.spongepowered.asm.util.Constants;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+final class EnumInfo implements Comparable<EnumInfo> {
+    private final ClassContext enumClass;
+    private final ClassContext targetClass;
+    private final String description;
+    private final List<FieldNode> selfTypedFields;
+    private final List<FieldNode> constants;
+    private final Set<String> constantNames;
+    private final FieldNode valuesField;
+    private final MethodNode clinit;
+    private final FieldInsnNode valuesAssignment;
+    private final String tieBreakString;
+
+    private EnumInfo(ClassContext enumClass, ClassContext targetClass, String description) throws AssumptionViolatedException {
+        this.enumClass = enumClass;
+        this.targetClass = targetClass;
+        this.description = description;
+        this.clinit = findClinit();
+        this.selfTypedFields = findSelfTypedFields();
+        this.constants = findEnumConstants();
+        this.constantNames = this.constants.stream().map(it -> it.name).collect(Collectors.toSet());
+        this.valuesField = findValuesField();
+        this.valuesAssignment = findValuesAssignment();
+        this.tieBreakString = this.constants.isEmpty() ? "" : this.constants.get(0).name;
+    }
+
+    public static EnumInfo forTarget(TargetClassContext target) throws AssumptionViolatedException {
+        return new EnumInfo(target, target, "target class");
+    }
+
+    public static EnumInfo forMixin(MixinTargetContext mixin) throws InvalidMixinException {
+        try {
+            return new EnumInfo(mixin, mixin.getTarget(), "mixin class");
+        } catch (AssumptionViolatedException ex) {
+            throw new InvalidMixinException(mixin, ex);
+        }
+    }
+
+    /**
+     * Returns the fields whose type is the type of the enum
+     */
+    public List<FieldNode> getSelfTypedFields() {
+        return this.selfTypedFields;
+    }
+
+    public List<FieldNode> getConstants() {
+        return this.constants;
+    }
+
+    public Set<String> getConstantNames() {
+        return this.constantNames;
+    }
+
+    public FieldInsnNode getValuesAssignment() {
+        return this.valuesAssignment;
+    }
+
+    public MethodNode getClinit() {
+        return this.clinit;
+    }
+
+    public boolean isEnumConstantAssignment(AbstractInsnNode insn) {
+        if (!(insn instanceof FieldInsnNode)) {
+            return false;
+        }
+        FieldInsnNode fieldInsn = (FieldInsnNode) insn;
+        return constantNames.contains(fieldInsn.name) && isAssignmentToOurStaticField(insn, fieldInsn.name, false);
+    }
+
+    @Override
+    public int compareTo(EnumInfo other) {
+        return this.tieBreakString.compareTo(other.tieBreakString);
+    }
+
+    private MethodNode findClinit() throws AssumptionViolatedException {
+        MethodNode clinit = Bytecode.findMethod(enumClass.getClassNode(), Constants.CLINIT, "()V");
+        if (clinit == null) {
+            throw assumptionViolated("Failed to find <clinit> in %s", this.description);
+        }
+        return clinit;
+    }
+
+    private FieldNode findValuesField() throws AssumptionViolatedException {
+        List<FieldNode> candidates = new ArrayList<>();
+        for (FieldNode field : this.enumClass.getClassNode().fields) {
+            if (Bytecode.isEnumValuesArray(field, this.targetClass.getClassNode())) {
+                candidates.add(field);
+            }
+        }
+        if (candidates.size() != 1) {
+            throw assumptionViolated(
+                    "Failed to determine enum values array in %s, candidates: %s",
+                    this.description, candidates.stream().map(it -> it.name).collect(Collectors.toList())
+            );
+        }
+        return candidates.get(0);
+    }
+
+    private FieldInsnNode findValuesAssignment() throws AssumptionViolatedException {
+        FieldInsnNode candidate = null;
+        for (AbstractInsnNode insn : this.clinit.instructions) {
+            if (isAssignmentToOurStaticField(insn, this.valuesField.name, true)) {
+                if (candidate == null) {
+                    candidate = (FieldInsnNode) insn;
+                } else {
+                    throw assumptionViolated(
+                            "Duplicate enum values assignment in %s (%s)",
+                            this.description, this.valuesField.name
+                    );
+                }
+            }
+        }
+        return candidate;
+    }
+
+    private List<FieldNode> findSelfTypedFields() {
+        String selfDesc = 'L' + this.targetClass.getClassRef() + ';';
+        List<FieldNode> result = new ArrayList<>();
+        for (FieldNode field : this.enumClass.getClassNode().fields) {
+            if (field.desc.equals(selfDesc)) {
+                result.add(field);
+            }
+        }
+        return result;
+    }
+
+    private List<FieldNode> findEnumConstants() {
+        List<FieldNode> result = new ArrayList<>();
+        for (FieldNode field : this.selfTypedFields) {
+            if (Bytecode.isEnumConstant(field, this.targetClass.getClassNode())) {
+                result.add(field);
+            }
+        }
+        return result;
+    }
+
+    private boolean isAssignmentToOurStaticField(AbstractInsnNode insn, String fieldName, boolean isArray) {
+        if (insn.getOpcode() != Opcodes.PUTSTATIC) {
+            return false;
+        }
+        FieldInsnNode fieldInsn = (FieldInsnNode) insn;
+        // We see instructions sometimes before remapping and sometimes after, try both
+        for (ClassContext context : new ClassContext[]{this.enumClass, this.targetClass}) {
+            if (fieldInsn.owner.equals(context.getClassRef())
+                    && fieldInsn.name.equals(fieldName)
+                    && fieldInsn.desc.equals((isArray ? "[L" : "L") + context.getClassRef() + ';')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static AssumptionViolatedException assumptionViolated(String template, Object... args) {
+        return new AssumptionViolatedException(String.format(template, args));
+    }
+
+    public static final class AssumptionViolatedException extends Exception {
+        private AssumptionViolatedException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/InnerClassGenerator.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/InnerClassGenerator.java
@@ -64,7 +64,7 @@ final class InnerClassGenerator implements IClassGenerator {
         /**
          * Mixin which provides this class
          */
-        private final IMixinInfo mixin;
+        private final MixinInfo mixin;
         
         /**
          * Target class info
@@ -101,7 +101,7 @@ final class InnerClassGenerator implements IClassGenerator {
          */
         private int loadCounter;
 
-        InnerClassInfo(IMixinInfo mixin, ClassInfo targetClass, ClassInfo nestHost, String originalName, String name, MixinInfo owner) {
+        InnerClassInfo(MixinInfo mixin, ClassInfo targetClass, ClassInfo nestHost, String originalName, String name, MixinInfo owner) {
             this.mixin = mixin;
             this.targetClassInfo = targetClass;
             this.originalName = originalName;
@@ -157,6 +157,9 @@ final class InnerClassGenerator implements IClassGenerator {
         
         void accept(final ClassVisitor classVisitor) throws ClassNotFoundException, IOException {
             ClassNode classNode = MixinService.getService().getBytecodeProvider().getClassNode(this.originalName);
+            if (this.loadCounter == 0) {
+                this.mixin.validateInnerClass(classNode);
+            }
             this.readInnerClasses(classNode);
             classNode.accept(classVisitor);
             this.loadCounter++;

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorEnum.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorEnum.java
@@ -261,6 +261,14 @@ class MixinApplicatorEnum extends MixinApplicatorStandard {
     }
 
     private void applyEnumFields(EnumInfo extension, MixinTargetContext mixin) {
+        // Remove existing stub constants
+        this.targetClass.fields.removeAll(
+                extension.getConstants().stream()
+                        .map(this::findTargetField)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet())
+        );
+
         List<FieldNode> targetFields = this.targetClass.fields;
         int insertionIndex = this.insertionPoint == null ? 0 : targetFields.lastIndexOf(this.insertionPoint) + 1;
 

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorEnum.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorEnum.java
@@ -1,0 +1,378 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin.transformer;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.*;
+import org.spongepowered.asm.mixin.MixinIntrinsics;
+import org.spongepowered.asm.mixin.extensibility.IActivityContext;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.asm.mixin.injection.struct.Target;
+import org.spongepowered.asm.mixin.transformer.struct.Clinit;
+import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
+import org.spongepowered.asm.util.Bytecode;
+import org.spongepowered.asm.util.Constants;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+class MixinApplicatorEnum extends MixinApplicatorStandard {
+    private final Map<IMixinInfo, EnumInfo> extensionInfos = new HashMap<>();
+    private EnumInfo targetInfo;
+    private int ordinalShift;
+    private FieldNode insertionPoint;
+
+    MixinApplicatorEnum(TargetClassContext context) {
+        super(context);
+    }
+
+    @Override
+    protected void preApply(IActivityContext.IActivity activity, List<MixinTargetContext> mixins) throws Exception {
+        this.gatherEnumExtensions(mixins);
+        this.sortEnumExtensions(mixins);
+
+        // Pre-apply in the right order now
+        super.preApply(activity, mixins);
+
+        // Target class is now ready
+        if (!this.extensionInfos.isEmpty()) {
+            this.prepareTargetInfo(mixins);
+            this.checkUniqueEnumConstants(mixins);
+            this.permitEnumSubclasses(mixins);
+            this.replaceValueOf();
+        }
+    }
+
+    private void gatherEnumExtensions(List<MixinTargetContext> mixins) {
+        for (Iterator<MixinTargetContext> iter = mixins.iterator(); iter.hasNext(); ) {
+            MixinTargetContext mixin = iter.next();
+            if (!mixin.getClassInfo().isEnum()) {
+                // Not an enum extension
+                continue;
+            }
+            try {
+                this.extensionInfos.put(mixin.getInfo(), EnumInfo.forMixin(mixin));
+            } catch (InvalidMixinException ex) {
+                if (mixin.isRequired()) {
+                    throw ex;
+                }
+                this.context.addSuppressed(ex);
+                iter.remove(); // Do not process this mixin further
+            }
+        }
+    }
+
+    private void sortEnumExtensions(List<MixinTargetContext> mixins) {
+        Comparator<MixinTargetContext> byEnumExtension =
+                Comparator.comparing(
+                        mixin -> this.extensionInfos.get(mixin.getInfo()),
+                        Comparator.nullsLast(Comparator.naturalOrder())
+                );
+        mixins.sort(Comparator.comparing(MixinTargetContext::getPriority).thenComparing(byEnumExtension));
+    }
+
+    private void prepareTargetInfo(List<MixinTargetContext> mixins) {
+        try {
+            this.targetInfo = EnumInfo.forTarget(this.context);
+            List<FieldNode> targetConstants = this.targetInfo.getConstants();
+            this.ordinalShift = targetConstants.size();
+            if (!targetConstants.isEmpty()) {
+                this.insertionPoint = targetConstants.get(targetConstants.size() - 1);
+            }
+        } catch (EnumInfo.AssumptionViolatedException e) {
+            // We can't enum extend this target. Blame all mixins who tried to.
+            for (Iterator<MixinTargetContext> iter = mixins.iterator(); iter.hasNext(); ) {
+                MixinTargetContext mixin = iter.next();
+
+                if (!mixin.getClassInfo().isEnum()) {
+                    // Not an enum extension
+                    continue;
+                }
+
+                InvalidMixinException wrapped = new InvalidMixinException(mixin, e);
+                if (mixin.isRequired()) {
+                    throw wrapped;
+                }
+                this.context.addSuppressed(wrapped);
+                iter.remove(); // Do not process this mixin further
+            }
+        }
+    }
+
+    private void checkUniqueEnumConstants(List<MixinTargetContext> mixins) {
+        Multimap<String, MixinTargetContext> existingSources = ArrayListMultimap.create();
+
+        for (FieldNode field : this.targetInfo.getSelfTypedFields()) {
+            existingSources.put(field.name, null);
+        }
+
+        for (MixinTargetContext mixin : mixins) {
+            for (FieldNode field : mixin.getFields()) {
+                if (field.desc.equals('L' + this.targetClass.name + ';')) {
+                    existingSources.put(field.name, mixin);
+                }
+            }
+        }
+
+        for (Iterator<MixinTargetContext> iter = mixins.iterator(); iter.hasNext(); ) {
+            MixinTargetContext mixin = iter.next();
+
+            EnumInfo extension = this.extensionInfos.get(mixin.getInfo());
+            if (extension == null) {
+                continue;
+            }
+
+            for (FieldNode constant : extension.getConstants()) {
+                Collection<MixinTargetContext> sources = existingSources.get(constant.name);
+                if (sources.size() >= 2) {
+                    // There is a conflict
+                    List<String> others =
+                            sources.stream()
+                                    .filter(it -> it != mixin)
+                                    .map(it -> it == null ? "target class" : it.toString())
+                                    .collect(Collectors.toList());
+                    InvalidMixinException e = new InvalidMixinException(
+                            mixin,
+                            String.format(
+                                    "Added enum constant %s conflicts with field declared in %s",
+                                    constant.name, others
+                            )
+                    );
+                    if (mixin.isRequired()) {
+                        throw e;
+                    }
+                    this.context.addSuppressed(e);
+                    iter.remove(); // Do not process this mixin further
+                    this.extensionInfos.remove(mixin.getInfo());
+                    break;
+                }
+            }
+        }
+    }
+
+    private void permitEnumSubclasses(List<MixinTargetContext> mixins) {
+        if (this.targetClass.permittedSubclasses == null || this.targetClass.permittedSubclasses.isEmpty()) {
+            // Not sealed in the first place
+            return;
+        }
+        for (MixinTargetContext mixin : mixins) {
+            if (!mixin.getClassInfo().isEnum()) {
+                // Not an enum extension
+                continue;
+            }
+            for (Map.Entry<String, String> names : mixin.getInnerClasses().entrySet()) {
+                ClassInfo innerClass = ClassInfo.forName(names.getKey());
+                if (innerClass.getSuperName().equals(mixin.getClassRef())) {
+                    // This is an enum subclass
+                    this.targetClass.permittedSubclasses.add(names.getValue());
+                }
+            }
+        }
+    }
+
+    /**
+     * Replaces the valueOf method with one that delegates to Enum#valueOf, in case the existing
+     * implementation is specific to the existing constants.
+     */
+    private void replaceValueOf() {
+        String valueOfDesc = "(Ljava/lang/String;)L" + this.targetClass.name + ';';
+        MethodNode existing = Bytecode.findMethod(this.targetClass, "valueOf", valueOfDesc);
+        this.targetClass.methods.remove(existing);
+
+        MethodNode valueOf = new MethodNode(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "valueOf", valueOfDesc, null, null);
+        this.targetClass.methods.add(valueOf);
+
+        valueOf.visitLdcInsn(Type.getObjectType(this.targetClass.name));
+        valueOf.visitVarInsn(Opcodes.ALOAD, 0);
+        valueOf.visitMethodInsn(
+                Opcodes.INVOKESTATIC,
+                Type.getInternalName(Enum.class),
+                "valueOf",
+                "(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;",
+                false
+        );
+        valueOf.visitTypeInsn(Opcodes.CHECKCAST, this.targetClass.name);
+        valueOf.visitInsn(Opcodes.ARETURN);
+        valueOf.visitMaxs(2, 1);
+    }
+
+    @Override
+    protected void applyNormalMethod(MixinTargetContext mixin, MethodNode mixinMethod) {
+        if (mixin.getClassInfo().isEnum() && Constants.CTOR.equals(mixinMethod.name) && Bytecode.hasFlag(mixinMethod, Opcodes.ACC_SYNTHETIC)) {
+            // Unusually, we actually want to merge this constructor.
+            // It will be from pre-Java 11 and will have in its descriptor one of this Mixin's inner classes, to emulate
+            // a nesting system. Because of this it cannot conflict with any other mixins, and the easiest way to keep
+            // things working is to merge it.
+            mixin.transformMethod(mixinMethod);
+            super.mergeMethod(mixin, mixinMethod);
+            return;
+        }
+        super.applyNormalMethod(mixin, mixinMethod);
+    }
+
+    @Override
+    protected void mergeNormalField(MixinTargetContext mixin, FieldNode field, int index) {
+        if (mixin.getClassInfo().isEnum()) {
+            if (Bytecode.isEnumConstant(field, targetClass)) {
+                // Skip merging for now, we'll do it later in order
+                return;
+            }
+            if (Bytecode.isEnumValuesArray(field, targetClass)) {
+                // Skip merging entirely
+                return;
+            }
+        }
+        super.mergeNormalField(mixin, field, index);
+    }
+
+    @Override
+    protected void applyFields(MixinTargetContext mixin) {
+        super.applyFields(mixin);
+
+        EnumInfo extension = this.extensionInfos.get(mixin.getInfo());
+        if (extension != null) {
+            this.applyEnumFields(extension, mixin);
+        }
+    }
+
+    private void applyEnumFields(EnumInfo extension, MixinTargetContext mixin) {
+        List<FieldNode> targetFields = this.targetClass.fields;
+        int insertionIndex = this.insertionPoint == null ? 0 : targetFields.lastIndexOf(this.insertionPoint) + 1;
+
+        for (FieldNode constant : extension.getConstants()) {
+            super.mergeNormalField(mixin, constant, insertionIndex++);
+            this.insertionPoint = constant;
+        }
+    }
+
+    @Override
+    protected Clinit prepareOrCreateClinit() {
+        return new EnumClinit();
+    }
+    
+    private class EnumClinit extends Clinit {
+        public EnumClinit() {
+            this(MixinApplicatorEnum.this.context.getTargetMethod(MixinApplicatorEnum.this.targetInfo.getClinit()));
+        }
+        
+        private EnumClinit(Target clinit) {
+            super(clinit.method, Clinit.prepareClinit(clinit.method, clinit));
+        }
+
+        @Override
+        protected void appendInsns(IMixinInfo mixinInfo, MethodNode mixinClinit, Map<LabelNode, LabelNode> labels) {
+            EnumInfo extension = MixinApplicatorEnum.this.extensionInfos.get(mixinInfo);
+            if (extension == null) {
+                // Not an enum extension
+                super.appendInsns(mixinInfo, mixinClinit, labels);
+                return;
+            }
+            
+            spliceEnumClinit(mixinInfo, extension, labels);
+        }
+
+        private void spliceEnumClinit(IMixinInfo mixinInfo, EnumInfo extension, Map<LabelNode, LabelNode> labels) {
+            Set<String> remainingConstants = new HashSet<>(extension.getConstantNames());
+            InsnList dest = this.clinit.instructions;
+            AbstractInsnNode insertPoint = MixinApplicatorEnum.this.targetInfo.getValuesAssignment();
+
+            InsnList insns = extension.getClinit().instructions;
+
+            // Splice in the enum constant initializers
+            Integer currentOrdinal = null;
+            for (AbstractInsnNode insn = insns.getFirst(); insn != extension.getValuesAssignment(); insn = insn.getNext()) {
+                if (currentOrdinal == null) {
+                    if (!remainingConstants.isEmpty()) {
+                        Object ordinal = Bytecode.getConstant(insn);
+                        if (ordinal instanceof Integer) {
+                            // Shift the ordinal up
+                            currentOrdinal = (int) ordinal + MixinApplicatorEnum.this.ordinalShift;
+                            dest.insertBefore(insertPoint, Bytecode.loadIntConstant(currentOrdinal));
+                            continue;
+                        }
+                    }
+                } else if (isCurrentOrdinalCall(insn)) {
+                    dest.insertBefore(insertPoint, Bytecode.loadIntConstant(currentOrdinal));
+                    continue;
+                }
+
+                dest.insertBefore(insertPoint, insn.clone(labels));
+
+                if (extension.isEnumConstantAssignment(insn)) {
+                    String constantName = ((FieldInsnNode) insn).name;
+                    if (!remainingConstants.remove(constantName)) {
+                        throw new InvalidMixinException(mixinInfo, "Duplicate assignment to enum constant " + constantName);
+                    }
+                    currentOrdinal = null;
+                    // Wait for the next one
+                }
+            }
+
+            if (!remainingConstants.isEmpty()) {
+                throw new InvalidMixinException(mixinInfo, "Enum constants not assigned: " + remainingConstants);
+            }
+
+            // We have the old array and the new array on the stack, concat them
+            insns.insertBefore(insertPoint, concatEnumValues());
+
+            // Merge in the rest of <clinit>
+            for (AbstractInsnNode insn = extension.getValuesAssignment().getNext(); insn != null; insn = insn.getNext()) {
+                if (insn.getOpcode() != Opcodes.RETURN) {
+                    dest.insertBefore(this.finalReturn, insn.clone(labels));
+                }
+            }
+
+            // Shift future ordinals up even more
+            MixinApplicatorEnum.this.ordinalShift += extension.getConstants().size();
+        }
+
+        private InsnList concatEnumValues() {
+            InsnList result = new InsnList();
+            result.add(
+                    new MethodInsnNode(
+                            Opcodes.INVOKESTATIC,
+                            Type.getInternalName(MixinHooks.class),
+                            "concatEnumValues",
+                            "([Ljava/lang/Enum;[Ljava/lang/Enum;)[Ljava/lang/Enum;",
+                            false
+                    )
+            );
+            result.add(new TypeInsnNode(Opcodes.CHECKCAST, "[L" + MixinApplicatorEnum.this.targetClass.name + ';'));
+            return result;
+        }
+
+        private boolean isCurrentOrdinalCall(AbstractInsnNode insn) {
+            if (insn.getOpcode() != Opcodes.INVOKESTATIC) {
+                return false;
+            }
+            MethodInsnNode call = (MethodInsnNode) insn;
+            return call.owner.equals(Type.getInternalName(MixinIntrinsics.class)) && call.name.equals("currentEnumOrdinal");
+        }
+    }
+
+}

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorStandard.java
@@ -230,10 +230,7 @@ class MixinApplicatorStandard {
         try {
             IActivity activity = this.activities.begin("PreApply Phase");
             IActivity preApplyActivity = this.activities.begin("Mixin");
-            for (MixinTargetContext context : mixinContexts) {
-                preApplyActivity.next(context.toString());
-                (current = context).preApply(this.targetName, this.targetClass);
-            }
+            this.preApply(preApplyActivity, mixinContexts);
             preApplyActivity.end();
             
             for (ApplicatorPass pass : ApplicatorPass.values()) {
@@ -273,6 +270,13 @@ class MixinApplicatorStandard {
         this.context.processDebugTasks();
     }
 
+    protected void preApply(IActivity activity, List<MixinTargetContext> mixins) throws Exception {
+        for (MixinTargetContext context : mixins) {
+            activity.next(context.toString());
+            context.preApply(this.targetName, this.targetClass);
+        }
+    }
+    
     private void runApplicatorPass(ApplicatorPass pass, List<MixinTargetContext> mixinContexts) {
         switch (pass) {
             case MAIN:
@@ -463,21 +467,25 @@ class MixinApplicatorStandard {
 
     protected void mergeNewFields(MixinTargetContext mixin) {
         for (FieldNode field : mixin.getFields()) {
-            FieldNode target = this.findTargetField(field);
-            if (target == null) {
-                // This is just a local field, so add it
-                this.targetClass.fields.add(field);
-                mixin.fieldMerged(field);
+            mergeNormalField(mixin, field, this.targetClass.fields.size());
+        }
+    }
 
-                if (field.signature != null) {
-                    if (this.mergeSignatures) {
-                        SignatureVisitor sv = mixin.getSignature().getRemapper();
-                        new SignatureReader(field.signature).accept(sv);
-                        field.signature = sv.toString();
-                    } else {
-                        field.signature = null;
-                    }
-                }
+    protected void mergeNormalField(MixinTargetContext mixin, FieldNode field, int index) {
+        FieldNode target = this.findTargetField(field);
+        if (target != null) {
+            return;
+        }
+        this.targetClass.fields.add(index, field);
+        mixin.fieldMerged(field);
+
+        if (field.signature != null) {
+            if (this.mergeSignatures) {
+                SignatureVisitor sv = mixin.getSignature().getRemapper();
+                new SignatureReader(field.signature).accept(sv);
+                field.signature = sv.toString();
+            } else {
+                field.signature = null;
             }
         }
     }
@@ -774,7 +782,7 @@ class MixinApplicatorStandard {
         }
     }
 
-    private Clinit prepareOrCreateClinit() {
+    protected Clinit prepareOrCreateClinit() {
         MethodNode clinit = Bytecode.findMethod(this.targetClass, Constants.CLINIT, "()V");
         if (clinit != null) {
             return Clinit.prepare(this.context.getTargetMethod(clinit));
@@ -791,7 +799,7 @@ class MixinApplicatorStandard {
         if (mixinClinit == null) {
             return;
         }
-        clinit.get().append(mixinClinit);
+        clinit.get().append(mixin.getMixin(), mixinClinit);
     }
 
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinHooks.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinHooks.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin.transformer;
+
+import java.util.Arrays;
+
+// Only for use in transformed code
+@SuppressWarnings("unused")
+public final class MixinHooks {
+    private MixinHooks() {}
+
+    public static Enum<?>[] concatEnumValues(Enum<?>[] existing, Enum<?>[] added) {
+        Enum<?>[] result = Arrays.copyOf(existing, existing.length + added.length);
+        System.arraycopy(added, 0, result, existing.length, added.length);
+        return result;
+    }
+}

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
@@ -60,6 +60,7 @@ import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
 import org.spongepowered.asm.mixin.transformer.throwables.MixinReloadException;
 import org.spongepowered.asm.mixin.transformer.throwables.MixinTargetAlreadyLoadedException;
 import org.spongepowered.asm.service.IClassTracker;
+import org.spongepowered.asm.service.IFeatureValidator;
 import org.spongepowered.asm.service.IMixinService;
 import org.spongepowered.asm.service.MixinService;
 import org.spongepowered.asm.util.Annotations;
@@ -675,6 +676,9 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
                     throw new InvalidMixinException(this.mixin, this.annotationType + " target type mismatch: "
                             + targetName + " is not an enum in " + this);
                 }
+
+                MixinService.getService().getFeatureValidator().validateEnumExtension(this.mixin, targetInfo);
+
                 if (this.mixin.getClassInfo().isFinal() != targetInfo.isFinal()) {
                     String us = this.mixin.getClassInfo().isFinal() ? "final" : "not final";
                     String them = targetInfo.isFinal() ? "final" : "not final";

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
@@ -46,16 +46,10 @@ import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.InnerClassNode;
 import org.objectweb.asm.tree.InvokeDynamicInsnNode;
 import org.objectweb.asm.tree.MethodNode;
-import org.spongepowered.asm.mixin.Implements;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel;
 import org.spongepowered.asm.mixin.MixinEnvironment.Option;
 import org.spongepowered.asm.mixin.MixinEnvironment.Phase;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Pseudo;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfig;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import org.spongepowered.asm.mixin.injection.Surrogate;
@@ -108,7 +102,12 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
         /**
          * Type proxy
          */
-        PROXY
+        PROXY,
+
+        /**
+         * Enum extension mixin
+         */
+        ENUM_EXTENSION
         
     }
     
@@ -540,6 +539,9 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
 
         abstract MixinPreProcessorStandard createPreProcessor(MixinClassNode classNode);
 
+        void validateInnerClass(ClassNode innerClass) {
+        }
+
         /**
          * A standard mixin
          */
@@ -661,6 +663,50 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
             }
         }
 
+        static class EnumExtension extends SubType {
+
+            EnumExtension(MixinInfo info) {
+                super(info, "@Mixin", false);
+            }
+
+            @Override
+            void validateTarget(String targetName, ClassInfo targetInfo) {
+                if (!targetInfo.isEnum()) {
+                    throw new InvalidMixinException(this.mixin, this.annotationType + " target type mismatch: "
+                            + targetName + " is not an enum in " + this);
+                }
+                if (this.mixin.getClassInfo().isFinal() != targetInfo.isFinal()) {
+                    String us = this.mixin.getClassInfo().isFinal() ? "final" : "not final";
+                    String them = targetInfo.isFinal() ? "final" : "not final";
+                    throw new InvalidMixinException(
+                            this.mixin,
+                            String.format(
+                                    "%s target type mismatch: mixin is %s but target %s is %s",
+                                    this.annotationType, us, targetName, them
+                            )
+                    );
+                }
+            }
+
+            @Override
+            void validate(State state, List<ClassInfo> targetClasses) {
+                if (FabricUtil.getCompatibility(this.mixin.getConfig()) < FabricUtil.COMPATIBILITY_0_17_1) {
+                    throw new InvalidMixinException(this.mixin, "Enum extensions require a compatibility level of at least 0.17.1");
+                }
+                EnumExtensionUtils.checkForGotchas(this.mixin, state.getValidationClassNode());
+            }
+
+            @Override
+            MixinPreProcessorStandard createPreProcessor(MixinClassNode classNode) {
+                return new MixinPreProcessorEnumExtension(this.mixin, classNode);
+            }
+
+            @Override
+            void validateInnerClass(ClassNode innerClass) {
+                EnumExtensionUtils.checkForGotchas(this.mixin, innerClass);
+            }
+        }
+
         static SubType getTypeFor(MixinInfo mixin) {
             Variant variant = MixinInfo.getVariant(mixin.getClassInfo());
             switch (variant) {
@@ -670,6 +716,8 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
                     return new SubType.Interface(mixin);
                 case ACCESSOR:
                     return new SubType.Accessor(mixin);
+                case ENUM_EXTENSION:
+                    return new EnumExtension(mixin);
                 default:
                     throw new IllegalStateException("Unsupported Mixin variant " + variant + " for " + mixin);
             }
@@ -897,6 +945,10 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
         } finally {
             this.pendingState = null;
         }
+    }
+
+    void validateInnerClass(ClassNode innerClass) {
+        this.type.validateInnerClass(innerClass);
     }
 
     /**
@@ -1371,7 +1423,11 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
 //        if (ProxyInfo.isProxy(classInfo)) {
 //            return Variant.PROXY;
 //        }
-        
+
+        if (classInfo.isEnum()) {
+            return Variant.ENUM_EXTENSION;
+        }
+
         if (!classInfo.isInterface()) {
             return Variant.STANDARD;
         }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
@@ -695,7 +695,8 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
             @Override
             void validate(State state, List<ClassInfo> targetClasses) {
                 if (FabricUtil.getCompatibility(this.mixin.getConfig()) < FabricUtil.COMPATIBILITY_0_17_1) {
-                    throw new InvalidMixinException(this.mixin, "Enum extensions require a compatibility level of at least 0.17.1");
+                    String advice = MixinService.getService().getAdviceProvider().higherCompatibilityNeeded(FabricUtil.COMPATIBILITY_0_17_1, "0.17.1");
+                    throw new InvalidMixinException(this.mixin, "Enum extensions are not supported at the current compatibility version. " + advice);
                 }
                 EnumExtensionUtils.checkForGotchas(this.mixin, state.getValidationClassNode());
             }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
@@ -175,10 +175,6 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
             return MixinInfo.this;
         }
         
-        public List<FieldNode> getFields() {
-            return new ArrayList<FieldNode>(this.fields);
-        }
-        
         @Override
         public MethodVisitor visitMethod(final int access, final String name, final String desc, final String signature, final String[] exceptions) {
             MethodNode method = new MixinMethodNode(access, name, desc, signature, exceptions);

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorEnumExtension.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorEnumExtension.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.asm.mixin.transformer;
+
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.transformer.MixinInfo.MixinClassNode;
+import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
+import org.spongepowered.asm.util.Annotations;
+import org.spongepowered.asm.util.Bytecode;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.List;
+
+class MixinPreProcessorEnumExtension extends MixinPreProcessorStandard {
+    private static final List<Class<? extends Annotation>> DISALLOWED_ANNOTATIONS_ON_CONSTANTS =
+            Arrays.asList(Shadow.class, Unique.class);
+
+    MixinPreProcessorEnumExtension(MixinInfo mixin, MixinClassNode classNode) {
+        super(mixin, classNode);
+    }
+
+    @Override
+    protected boolean validateField(MixinTargetContext context, FieldNode field, AnnotationNode shadow) {
+        if (Bytecode.isEnumConstant(field, classNode)) {
+            for (Class<? extends Annotation> annotation : DISALLOWED_ANNOTATIONS_ON_CONSTANTS) {
+                if (Annotations.getVisible(field, annotation) != null) {
+                    throw new InvalidMixinException(context, String.format("Enum constant %s in %s has @%s annotation. This is not allowed.",
+                            field.name, context, annotation.getSimpleName()));
+                }
+            }
+            // Public static fields normally aren't allowed, but enum values are excused
+            return true;
+        }
+        return super.validateField(context, field, shadow);
+    }
+
+    @Override
+    protected boolean validateMethod(MixinTargetContext context, MixinInfo.MixinMethodNode mixinMethod) {
+        String mixinClassDesc = 'L' + this.mixin.getClassRef() + ';';
+        if (mixinMethod.name.equals("values") && mixinMethod.desc.equals("()[" + mixinClassDesc)) {
+            // Skip the values() method
+            return false;
+        }
+        if (mixinMethod.name.equals("valueOf") && mixinMethod.desc.equals("(Ljava/lang/String;)" + mixinClassDesc)) {
+            // Skip the valueOf(String) method
+            return false;
+        }
+        return super.validateMethod(context, mixinMethod);
+    }
+}

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorEnumExtension.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorEnumExtension.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.asm.mixin.transformer;
 
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.FieldNode;
 import org.spongepowered.asm.mixin.Shadow;
@@ -32,6 +33,7 @@ import org.spongepowered.asm.mixin.transformer.MixinInfo.MixinClassNode;
 import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
 import org.spongepowered.asm.util.Annotations;
 import org.spongepowered.asm.util.Bytecode;
+import org.spongepowered.asm.util.Constants;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
@@ -43,6 +45,16 @@ class MixinPreProcessorEnumExtension extends MixinPreProcessorStandard {
 
     MixinPreProcessorEnumExtension(MixinInfo mixin, MixinClassNode classNode) {
         super(mixin, classNode);
+    }
+
+    @Override
+    protected void prepareShadow(MixinInfo.MixinMethodNode mixinMethod, ClassInfo.Method method) {
+        if (Constants.CTOR.equals(mixinMethod.name) && !Bytecode.hasFlag(mixinMethod, Opcodes.ACC_SYNTHETIC)) {
+            // In enum extensions, constructors are always implicitly @Shadow s (except synthetic ones which will be
+            // merged and so don't need to match anything).
+            Annotations.setVisible(mixinMethod, Shadow.class);
+        }
+        super.prepareShadow(mixinMethod, method);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
@@ -677,9 +677,6 @@ class MixinPreProcessorStandard {
                 mixinField.name = field.renameTo(target.name);
             }
             
-            // Shadow fields get stripped from the mixin class
-            iter.remove();
-            
             if (isShadow) {
                 boolean isFinal = field.isDecoratedFinal();
                 if (this.verboseLogging && Bytecode.hasFlag(target, Opcodes.ACC_FINAL) != isFinal) {
@@ -689,6 +686,8 @@ class MixinPreProcessorStandard {
                     MixinPreProcessorStandard.logger.warn(message, this.mixin, mixinField.name);
                 }
 
+                // Shadow fields get stripped from the mixin class
+                iter.remove();
                 context.addShadowField(mixinField, field);
             }
         }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
@@ -220,6 +220,15 @@ class MixinPreProcessorStandard {
         if (shadowAnnotation == null) {
             return;
         }
+
+        if (Constants.CTOR.equals(mixinMethod.name)) {
+            for (String disallowedKey : new String[] {"prefix", "aliases"}) {
+                if (Annotations.getValue(shadowAnnotation, disallowedKey) != null) {
+                    throw new InvalidMixinException(this.mixin, String.format("@Shadow constructor %s.%s declares %s. This is not allowed.",
+                            this.mixin, mixinMethod, disallowedKey));
+                }
+            }
+        }
         
         String prefix = Annotations.<String>getValue(shadowAnnotation, "prefix", Shadow.class);
         if (mixinMethod.name.startsWith(prefix)) {
@@ -433,17 +442,17 @@ class MixinPreProcessorStandard {
             target = context.findRemappedMethod(mixinMethod);
             if (target == null) {
                 throw new InvalidMixinException(this.mixin,
-                        String.format("%s method %s in %s was not located in the target class %s. %s%s", type, mixinMethod.name, this.mixin,
+                        String.format("%s method %s%s in %s was not located in the target class %s. %s%s", type, mixinMethod.name, mixinMethod.desc, this.mixin,
                                 context.getTarget(), context.getReferenceMapper().getStatus(),
                                 MixinPreProcessorStandard.getDynamicInfo(mixinMethod)));
             }
             mixinMethod.name = method.renameTo(target.name);
         }
         
-        if (Constants.CTOR.equals(target.name)) {
+        if (Constants.CTOR.equals(target.name) && !Constants.CTOR.equals(mixinMethod.name)) {
             throw new InvalidMixinException(this.mixin, String.format("Nice try! %s in %s cannot alias a constructor", mixinMethod.name, this.mixin));
         }
-        
+
         if (!Bytecode.compareFlags(mixinMethod, target, Opcodes.ACC_STATIC)) {
             throw new InvalidMixinException(this.mixin, String.format("STATIC modifier of %s method %s in %s does not match the target", type,
                     mixinMethod.name, this.mixin));
@@ -463,6 +472,11 @@ class MixinPreProcessorStandard {
     }
 
     private void conformVisibility(MixinTargetContext context, MixinMethodNode mixinMethod, SpecialMethod type, MethodNode target) {
+        if (Constants.CTOR.equals(mixinMethod.name)) {
+            // No need to change invocation opcodes
+            return;
+        }
+
         Visibility visTarget = Bytecode.getVisibility(target);
         Visibility visMethod = Bytecode.getVisibility(mixinMethod);
         if (visMethod.ordinal() >= visTarget.ordinal()) {
@@ -489,7 +503,7 @@ class MixinPreProcessorStandard {
     }
 
     protected Method getSpecialMethod(MixinMethodNode mixinMethod, SpecialMethod type) {
-        Method method = this.mixin.getClassInfo().findMethod(mixinMethod, ClassInfo.INCLUDE_ALL);
+        Method method = this.mixin.getClassInfo().findMethod(mixinMethod, ClassInfo.INCLUDE_ALL | ClassInfo.INCLUDE_INITIALISERS);
         this.checkMethodNotUnique(method, type);
         return method;
     }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinPreProcessorStandard.java
@@ -593,7 +593,7 @@ class MixinPreProcessorStandard {
 
     protected void attachFields(MixinTargetContext context) {
         IActivity fieldActivity = this.activities.begin("?");
-        for (Iterator<FieldNode> iter = this.classNode.getFields().iterator(); iter.hasNext();) {
+        for (Iterator<FieldNode> iter = this.classNode.fields.iterator(); iter.hasNext();) {
             FieldNode mixinField = iter.next();
             fieldActivity.next("%s:%s", mixinField.name, mixinField.desc);
             AnnotationNode shadow = Annotations.getVisible(mixinField, Shadow.class);

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -916,9 +916,6 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
      * @param field Field node to transform
      */
     void transformDescriptor(FieldNode field) {
-        if (!this.inheritsFromMixin && this.innerClasses.size() == 0) {
-            return;
-        }
         field.desc = this.transformSingleDescriptor(field.desc, false);
     }
     
@@ -928,9 +925,6 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
      * @param method Method node to transform
      */
     void transformDescriptor(MethodNode method) {
-        if (!this.inheritsFromMixin && this.innerClasses.size() == 0) {
-            return;
-        }
         method.desc = this.transformMethodDescriptor(method.desc);
     }
 
@@ -941,9 +935,6 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
      * @param member Reference to the method or field
      */
     void transformDescriptor(MemberRef member) {
-        if (!this.inheritsFromMixin && this.innerClasses.size() == 0) {
-            return;
-        }
         if (member.isField()) {
             member.setDesc(this.transformSingleDescriptor(member.getDesc(), false));
         } else {
@@ -957,9 +948,6 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
      * @param typeInsn Type instruction node to transform
      */
     void transformDescriptor(TypeInsnNode typeInsn) {
-        if (!this.inheritsFromMixin && this.innerClasses.size() == 0) {
-            return;
-        }
         typeInsn.desc = this.transformSingleDescriptor(typeInsn.desc, true);
     }
 

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/TargetClassContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/TargetClassContext.java
@@ -455,6 +455,9 @@ final class TargetClassContext extends ClassContext implements ITargetClassConte
     }
 
     private MixinApplicatorStandard createApplicator() {
+        if (this.classInfo.isEnum()) {
+            return new MixinApplicatorEnum(this);
+        }
         if (this.classInfo.isInterface()) {
             return new MixinApplicatorInterface(this);
         }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/struct/Clinit.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/struct/Clinit.java
@@ -26,6 +26,7 @@ package org.spongepowered.asm.mixin.transformer.struct;
 
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.*;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import org.spongepowered.asm.mixin.injection.struct.InjectionNodes;
 import org.spongepowered.asm.mixin.injection.struct.Target;
 import org.spongepowered.asm.util.Bytecode;
@@ -34,23 +35,20 @@ import java.util.ListIterator;
 import java.util.Map;
 
 public class Clinit {
-    private final MethodNode clinit;
-    private final AbstractInsnNode finalReturn;
+    protected final MethodNode clinit;
+    protected final AbstractInsnNode finalReturn;
 
     public Clinit(MethodNode clinit, AbstractInsnNode finalReturn) {
         this.clinit = clinit;
         this.finalReturn = finalReturn;
     }
 
-    public void append(MethodNode mixinClinit) {
+    public void append(IMixinInfo mixinInfo, MethodNode mixinClinit) {
         prepareClinit(mixinClinit, null);
+
         Map<LabelNode, LabelNode> labels = Bytecode.cloneLabels(mixinClinit.instructions);
-        for (AbstractInsnNode insn : mixinClinit.instructions) {
-            if (insn.getOpcode() == Opcodes.RETURN) {
-                continue;
-            }
-            this.clinit.instructions.insertBefore(this.finalReturn, insn.clone(labels));
-        }
+        this.appendInsns(mixinInfo, mixinClinit, labels);
+        
         this.clinit.maxLocals = Math.max(this.clinit.maxLocals, mixinClinit.maxLocals);
         this.clinit.maxStack = Math.max(this.clinit.maxStack, mixinClinit.maxStack);
         for (TryCatchBlockNode tryCatch : mixinClinit.tryCatchBlocks) {
@@ -58,6 +56,15 @@ public class Clinit {
         }
         for (LocalVariableNode local : mixinClinit.localVariables) {
             this.clinit.localVariables.add(new LocalVariableNode(local.name, local.desc, local.signature, labels.get(local.start), labels.get(local.end), local.index));
+        }
+    }
+    
+    protected void appendInsns(IMixinInfo mixinInfo, MethodNode mixinClinit, Map<LabelNode, LabelNode> labels) {
+        for (AbstractInsnNode insn : mixinClinit.instructions) {
+            if (insn.getOpcode() == Opcodes.RETURN) {
+                continue;
+            }
+            this.clinit.instructions.insertBefore(this.finalReturn, insn.clone(labels));
         }
     }
 
@@ -68,7 +75,7 @@ public class Clinit {
     /**
      * Rewrites RETURN instructions to instead GOTO a final RETURN instruction, and returns said instruction.
      */
-    private static AbstractInsnNode prepareClinit(MethodNode clinit, Target target) {
+    protected static AbstractInsnNode prepareClinit(MethodNode clinit, Target target) {
         LabelNode endLabel = new LabelNode();
         AbstractInsnNode existingFinalReturn = null;
         for (ListIterator<AbstractInsnNode> iter = clinit.instructions.iterator(); iter.hasNext(); ) {

--- a/src/main/java/org/spongepowered/asm/service/IAdviceProvider.java
+++ b/src/main/java/org/spongepowered/asm/service/IAdviceProvider.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.asm.service;
+
+/**
+ * Advice providers are responsible for providing suggestions to solve service-specific problems.
+ */
+public interface IAdviceProvider {
+    /**
+     * Advise the user on how to increase their compatibility version.
+     * @param requiredCompatibility the required compatibility version
+     * @param requiredCompatibilityString the required compatibility version as a string, in case it is useful in messages
+     */
+    public abstract String higherCompatibilityNeeded(int requiredCompatibility, String requiredCompatibilityString);
+
+    /**
+     * Returns generic advice for all situations. You should prefer implementing specific advice for your service.
+     */
+    public static final IAdviceProvider GENERIC = new IAdviceProvider() {
+        @Override
+        public String higherCompatibilityNeeded(int requiredCompatibility, String requiredCompatibilityString) {
+            return "Increase your compatibility version to at least " + requiredCompatibilityString;
+        }
+    };
+}

--- a/src/main/java/org/spongepowered/asm/service/IFeatureValidator.java
+++ b/src/main/java/org/spongepowered/asm/service/IFeatureValidator.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.asm.service;
+
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.asm.mixin.transformer.ClassInfo;
+import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
+
+/**
+ * Feature validators are responsible for deciding if certain features are allowed in given contexts.
+ */
+public interface IFeatureValidator {
+    /**
+     * Decides whether the given mixin can enum-extend the given target class.
+     * If not, should throw an {@link InvalidMixinException} with an informative error as to why this is not allowed.
+     * @param mixin the enum extension Mixin
+     * @param targetClass the target class the Mixin is trying to extend
+     */
+    public abstract void validateEnumExtension(IMixinInfo mixin, ClassInfo targetClass) throws InvalidMixinException;
+
+    /**
+     * Allows all features.
+     */
+    public static final IFeatureValidator ALLOW_ALL = new IFeatureValidator() {
+        @Override
+        public void validateEnumExtension(IMixinInfo mixin, ClassInfo targetClass) throws InvalidMixinException {
+        }
+    };
+}

--- a/src/main/java/org/spongepowered/asm/service/IMixinService.java
+++ b/src/main/java/org/spongepowered/asm/service/IMixinService.java
@@ -135,6 +135,12 @@ public interface IMixinService {
      * and services must not return null.</b>
      */
     public abstract IFeatureValidator getFeatureValidator();
+
+    /**
+     * Return the advice provider for this service. <b>This component is required
+     * and services must not return null.</b>
+     */
+    public abstract IAdviceProvider getAdviceProvider();
     
     /**
      * Get additional platform agents for this service 

--- a/src/main/java/org/spongepowered/asm/service/IMixinService.java
+++ b/src/main/java/org/spongepowered/asm/service/IMixinService.java
@@ -129,6 +129,12 @@ public interface IMixinService {
      * functionality.</b>
      */
     public abstract IMixinAuditTrail getAuditTrail();
+
+    /**
+     * Return the feature validator for this service. <b>This component is required
+     * and services must not return null.</b>
+     */
+    public abstract IFeatureValidator getFeatureValidator();
     
     /**
      * Get additional platform agents for this service 

--- a/src/main/java/org/spongepowered/asm/util/Bytecode.java
+++ b/src/main/java/org/spongepowered/asm/util/Bytecode.java
@@ -946,7 +946,7 @@ public final class Bytecode {
             if (insn.getOpcode() == Opcodes.BIPUSH || insn.getOpcode() == Opcodes.SIPUSH) {
                 return Integer.valueOf(value);
             }
-            throw new IllegalArgumentException("IntInsnNode with invalid opcode " + insn.getOpcode() + " in getConstant");
+            return null;
         } else if (insn instanceof TypeInsnNode) {
             if (insn.getOpcode() < Opcodes.CHECKCAST) {
                 return null; // Don't treat NEW and ANEWARRAY as constants 

--- a/src/main/java/org/spongepowered/asm/util/Bytecode.java
+++ b/src/main/java/org/spongepowered/asm/util/Bytecode.java
@@ -1409,4 +1409,24 @@ public final class Bytecode {
         return destination;
     }
 
+    public static boolean isEnumValuesArray(FieldNode field, ClassNode enumClass) {
+        return Bytecode.hasFlag(field, Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC) && field.desc.equals("[L" + enumClass.name + ';');
+    }
+
+    public static boolean isEnumConstant(FieldNode field, ClassNode enumClass) {
+        return Bytecode.hasFlag(field, Opcodes.ACC_STATIC | Opcodes.ACC_ENUM) && field.desc.equals('L' + enumClass.name + ';');
+    }
+
+    public static AbstractInsnNode loadIntConstant(int intValue) {
+        if (-1 <= intValue && intValue <= 5) {
+            return new InsnNode(Opcodes.ICONST_0 + intValue);
+        } else if (Byte.MIN_VALUE <= intValue && intValue <= Byte.MAX_VALUE) {
+            return new IntInsnNode(Opcodes.BIPUSH, intValue);
+        } else if (Short.MIN_VALUE <= intValue && intValue <= Short.MAX_VALUE) {
+            return new IntInsnNode(Opcodes.SIPUSH, intValue);
+        } else {
+            return new LdcInsnNode(intValue);
+        }
+    }
+
 }

--- a/src/modlauncher/java/org/spongepowered/asm/service/modlauncher/MixinServiceModLauncher.java
+++ b/src/modlauncher/java/org/spongepowered/asm/service/modlauncher/MixinServiceModLauncher.java
@@ -268,6 +268,14 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
         return IFeatureValidator.ALLOW_ALL;
     }
 
+    /* (non-Javadoc)
+     * @see org.spongepowered.asm.service.IMixinService#getAdviceProvider()
+     */
+    @Override
+    public IAdviceProvider getAdviceProvider() {
+        return IAdviceProvider.GENERIC;
+    }
+
     /**
      * Get (or create) the transformation handler
      */

--- a/src/modlauncher/java/org/spongepowered/asm/service/modlauncher/MixinServiceModLauncher.java
+++ b/src/modlauncher/java/org/spongepowered/asm/service/modlauncher/MixinServiceModLauncher.java
@@ -35,13 +35,7 @@ import org.spongepowered.asm.logging.ILogger;
 import org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel;
 import org.spongepowered.asm.mixin.MixinEnvironment.Phase;
 import org.spongepowered.asm.mixin.transformer.IMixinTransformerFactory;
-import org.spongepowered.asm.service.IClassBytecodeProvider;
-import org.spongepowered.asm.service.IClassProvider;
-import org.spongepowered.asm.service.IClassTracker;
-import org.spongepowered.asm.service.IMixinAuditTrail;
-import org.spongepowered.asm.service.IMixinInternal;
-import org.spongepowered.asm.service.ITransformerProvider;
-import org.spongepowered.asm.service.MixinServiceAbstract;
+import org.spongepowered.asm.service.*;
 import org.spongepowered.asm.util.IConsumer;
 
 import com.google.common.collect.ImmutableList;
@@ -264,6 +258,14 @@ public class MixinServiceModLauncher extends MixinServiceAbstract {
             this.auditTrail = new ModLauncherAuditTrail();
         }
         return this.auditTrail;
+    }
+
+    /* (non-Javadoc)
+     * @see org.spongepowered.asm.service.IMixinService#getFeatureValidator()
+     */
+    @Override
+    public IFeatureValidator getFeatureValidator() {
+        return IFeatureValidator.ALLOW_ALL;
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/FabricMC/Mixin/issues/190
Commits best consumed individually.

Requires https://github.com/LlamaLad7/fabric-loader/tree/temp/enum-extensions-testing

This adds enum extensions, which follow the general shape of:
```java
@Mixin(TargetEnum.class)
public enum EnumMixin {
    ADDED_CONSTANT_1("a"),
    ADDED_CONSTANT_2("b");

    @Shadow
    private EnumMixin(String example) {
    }
}
```

They require the as-yet-unreleased compat level of 0.17.1, partially to encourage migrating but also because they make use of the new `<clinit>` logic.

Notable features include:
- Support for abstract enums (most of the work is done by the existing inner class handling)
- The `MixinIntrinsics.currentEnumOrdinal()` method which can be used in enum initializers to access the relevant constant's final ordinal
- Detection and helpful error for accidental switching on the ordinal of an enum mixin, which can cause incorrect jump tables to be generated.
- Special handling of a custom field attribute which can be set by ClassTweaker to indicate stub enum constants
- Helpful error messages for duplicate constant declarations either in 2 mixins or in 1 mixin and the target class (stubs don't count)
- Deterministic application order for enum extensions in a given priority (sorted lexicographically by first added constant)
- Various bug fixes
- New support for `@Shadow` on constructors. Declared constructors can already implicitly shadow, but `@Shadow` has the benefit of failing fast if a matching constructor is not found. All constructors in enum extensions are assumed to have `@Shadow` implicitly, unlike constructors in normal mixins which must be assumed to be there only to appease the compiler

We make some (relatively minor) assumptions about the structure of enum classes, throwing informative errors if any of them are violated. 
For both mixin enums and target enums we assume:
- There will be a values array which is the only field marked static, synthetic, and with the type of `ThisClass[]`
- There will be 1 assignment to this array
- There will be 1 assignment to each enum constant

For mixin enums we additionally assume:
- In `<clinit>`, the first loaded int constant will be the ordinal of the first enum constant, and then after that enum constant is assigned, the next loaded int constant will be the ordinal of the second enum constant, etc