### PR TITLE
Fix: Include fabric compatibility in ModifyVariable decoration key.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/modify/ModifyVariableInjector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/modify/ModifyVariableInjector.java
@@ -32,6 +32,7 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.VarInsnNode;
+import org.spongepowered.asm.mixin.FabricUtil;
 import org.spongepowered.asm.mixin.injection.InjectionPoint;
 import org.spongepowered.asm.mixin.injection.InjectionPoint.RestrictTargetLevel;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
@@ -168,7 +169,11 @@ public class ModifyVariableInjector extends Injector {
      * @return Key for storing/retrieving the injector context decoration
      */
     protected String getTargetNodeKey(Target target, InjectionNode node) {
-        return String.format("localcontext(%s,%s,#%s)", this.returnType, this.discriminator.isArgsOnly() ? "argsOnly" : "fullFrame", node.getId());
+        return String.format(
+                "localcontext(%s,%s,#%s,%s)",
+                this.returnType, this.discriminator.isArgsOnly() ? "argsOnly" : "fullFrame", node.getId(),
+                FabricUtil.getCompatibility(this.info)
+        );
     }
     
     @Override


### PR DESCRIPTION
This was in fact missed in #82 and has been an issue since then, however it was unnoticed possibly due to the tighter conditions for a collision.

It has resurged since we changed the locals logic again for 0.17.0