### PR TITLE
Fix: Remove requirement for enum extension finalness to match target.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorEnum.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinApplicatorEnum.java
@@ -176,21 +176,33 @@ class MixinApplicatorEnum extends MixinApplicatorStandard {
     }
 
     private void permitEnumSubclasses(List<MixinTargetContext> mixins) {
-        if (this.targetClass.permittedSubclasses == null || this.targetClass.permittedSubclasses.isEmpty()) {
-            // Not sealed in the first place
+        boolean isSealed;
+        if (Bytecode.hasFlag(this.targetClass, Opcodes.ACC_FINAL)) {
+            isSealed = false;
+        } else if (this.targetClass.permittedSubclasses != null && !this.targetClass.permittedSubclasses.isEmpty()) {
+            isSealed = true;
+        } else {
+            // Is neither final nor sealed, so allows arbitrary subclasses already
             return;
         }
         for (MixinTargetContext mixin : mixins) {
-            if (!mixin.getClassInfo().isEnum()) {
-                // Not an enum extension
+            if (!mixin.getClassInfo().isEnum() || mixin.getClassInfo().isFinal()) {
+                // Not a subclassable enum extension
                 continue;
             }
-            for (Map.Entry<String, String> names : mixin.getInnerClasses().entrySet()) {
-                ClassInfo innerClass = ClassInfo.forName(names.getKey());
-                if (innerClass.getSuperName().equals(mixin.getClassRef())) {
-                    // This is an enum subclass
-                    this.targetClass.permittedSubclasses.add(names.getValue());
+            if (isSealed) {
+                // Permit the specific subclasses we have
+                for (Map.Entry<String, String> names : mixin.getInnerClasses().entrySet()) {
+                    ClassInfo innerClass = ClassInfo.forName(names.getKey());
+                    if (innerClass.getSuperName().equals(mixin.getClassRef())) {
+                        // This is an enum subclass
+                        this.targetClass.permittedSubclasses.add(names.getValue());
+                    }
                 }
+            } else {
+                // Simply make the target non-final
+                this.targetClass.access &= ~Opcodes.ACC_FINAL;
+                return;
             }
         }
     }

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinInfo.java
@@ -60,7 +60,6 @@ import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
 import org.spongepowered.asm.mixin.transformer.throwables.MixinReloadException;
 import org.spongepowered.asm.mixin.transformer.throwables.MixinTargetAlreadyLoadedException;
 import org.spongepowered.asm.service.IClassTracker;
-import org.spongepowered.asm.service.IFeatureValidator;
 import org.spongepowered.asm.service.IMixinService;
 import org.spongepowered.asm.service.MixinService;
 import org.spongepowered.asm.util.Annotations;
@@ -678,18 +677,6 @@ class MixinInfo implements Comparable<MixinInfo>, IMixinInfo {
                 }
 
                 MixinService.getService().getFeatureValidator().validateEnumExtension(this.mixin, targetInfo);
-
-                if (this.mixin.getClassInfo().isFinal() != targetInfo.isFinal()) {
-                    String us = this.mixin.getClassInfo().isFinal() ? "final" : "not final";
-                    String them = targetInfo.isFinal() ? "final" : "not final";
-                    throw new InvalidMixinException(
-                            this.mixin,
-                            String.format(
-                                    "%s target type mismatch: mixin is %s but target %s is %s",
-                                    this.annotationType, us, targetName, them
-                            )
-                    );
-                }
             }
 
             @Override


### PR DESCRIPTION
This improves usability, but is also crucial to ensure someone making the target enum `extendable` doesn't break other enum extensions.

Closes #202