### PR TITLE
Match `javac` INVOKESPECIAL/INVOKEVIRTUAL for generated invoker methods based on mixin class version

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGeneratorMethodProxy.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGeneratorMethodProxy.java
@@ -30,6 +30,7 @@ import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.VarInsnNode;
+import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.util.Bytecode;
 
 /**
@@ -52,11 +53,18 @@ public class AccessorGeneratorMethodProxy extends AccessorGenerator {
      */
     protected final Type returnType;
 
+    /**
+     * Minimum required class version for the accessor. Used to determine whether to emit INVOKEVIRTUAL or INVOKESPECIAL
+     * for private method calls, matching javac. See <a href="https://openjdk.org/jeps/181">JEP 181</a>.
+     */
+    protected final int minRequiredClassVersion;
+
     public AccessorGeneratorMethodProxy(AccessorInfo info) {
         super(info, Bytecode.isStatic(info.getTargetMethod()));
         this.targetMethod = info.getTargetMethod();
         this.argTypes = info.getArgTypes();
         this.returnType = info.getReturnType();
+        this.minRequiredClassVersion = info.minRequiredClassVersion;
         this.checkModifiers();
     }
     
@@ -65,6 +73,7 @@ public class AccessorGeneratorMethodProxy extends AccessorGenerator {
         this.targetMethod = info.getTargetMethod();
         this.argTypes = info.getArgTypes();
         this.returnType = info.getReturnType();
+        this.minRequiredClassVersion = info.minRequiredClassVersion;
     }
 
     @Override
@@ -77,7 +86,9 @@ public class AccessorGeneratorMethodProxy extends AccessorGenerator {
         Bytecode.loadArgs(this.argTypes, method.instructions, this.info.isStatic ? 0 : 1);
         boolean isInterface = Bytecode.hasFlag(this.info.getClassNode(), Opcodes.ACC_INTERFACE);
         boolean isPrivate = Bytecode.hasFlag(this.targetMethod, Opcodes.ACC_PRIVATE);
-        int opcode = this.targetIsStatic ? Opcodes.INVOKESTATIC : isInterface ? Opcodes.INVOKEINTERFACE : (isPrivate ? Opcodes.INVOKESPECIAL : Opcodes.INVOKEVIRTUAL);
+        int opcode = this.targetIsStatic ? Opcodes.INVOKESTATIC : isInterface ? Opcodes.INVOKEINTERFACE : (
+                isPrivate && minRequiredClassVersion < MixinEnvironment.CompatibilityLevel.JAVA_11.getClassVersion() ? Opcodes.INVOKESPECIAL : Opcodes.INVOKEVIRTUAL
+        );
         method.instructions.add(new MethodInsnNode(opcode, this.info.getClassNode().name, this.targetMethod.name, this.targetMethod.desc, isInterface));
         method.instructions.add(new InsnNode(this.returnType.getOpcode(Opcodes.IRETURN)));
         return method;

--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGeneratorMethodProxy.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGeneratorMethodProxy.java
@@ -27,11 +27,8 @@ package org.spongepowered.asm.mixin.gen;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.InsnNode;
-import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.VarInsnNode;
-import org.spongepowered.asm.mixin.MixinEnvironment;
-import org.spongepowered.asm.mixin.transformer.MixinTargetContext;
 import org.spongepowered.asm.util.Bytecode;
 
 /**
@@ -77,16 +74,7 @@ public class AccessorGeneratorMethodProxy extends AccessorGenerator {
             method.instructions.add(new VarInsnNode(Opcodes.ALOAD, 0));
         }
         Bytecode.loadArgs(this.argTypes, method.instructions, this.info.isStatic ? 0 : 1);
-        boolean isInterface = Bytecode.hasFlag(this.info.getClassNode(), Opcodes.ACC_INTERFACE);
-        boolean isPrivate = Bytecode.hasFlag(this.targetMethod, Opcodes.ACC_PRIVATE);
-        int opcode = this.targetIsStatic ? Opcodes.INVOKESTATIC : isInterface ? Opcodes.INVOKEINTERFACE : (
-                // This cast to MixinTargetContext is safe.
-                // This is because `getMixin()` is final, and returns AnnotatedMethodInfo.context.
-                // This field is set in the constructor, and the `super` ctor call in SpecialMethodInfo
-                // (which AccessorInfo is) passes a MixinTargetContext, strictly, from its ctor argument type.
-                isPrivate && ((MixinTargetContext) info.getMixin()).getMinRequiredClassVersion() < MixinEnvironment.CompatibilityLevel.JAVA_11.getClassVersion() ? Opcodes.INVOKESPECIAL : Opcodes.INVOKEVIRTUAL
-        );
-        method.instructions.add(new MethodInsnNode(opcode, this.info.getClassNode().name, this.targetMethod.name, this.targetMethod.desc, isInterface));
+        method.instructions.add(Bytecode.invokeMethod(this.info.getTargetClassNode(), this.targetMethod, this.info.getMixin()));
         method.instructions.add(new InsnNode(this.returnType.getOpcode(Opcodes.IRETURN)));
         return method;
     }

--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGeneratorMethodProxy.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGeneratorMethodProxy.java
@@ -31,6 +31,7 @@ import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.VarInsnNode;
 import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.transformer.MixinTargetContext;
 import org.spongepowered.asm.util.Bytecode;
 
 /**
@@ -53,18 +54,11 @@ public class AccessorGeneratorMethodProxy extends AccessorGenerator {
      */
     protected final Type returnType;
 
-    /**
-     * Minimum required class version for the accessor. Used to determine whether to emit INVOKEVIRTUAL or INVOKESPECIAL
-     * for private method calls, matching javac. See <a href="https://openjdk.org/jeps/181">JEP 181</a>.
-     */
-    protected final int minRequiredClassVersion;
-
     public AccessorGeneratorMethodProxy(AccessorInfo info) {
         super(info, Bytecode.isStatic(info.getTargetMethod()));
         this.targetMethod = info.getTargetMethod();
         this.argTypes = info.getArgTypes();
         this.returnType = info.getReturnType();
-        this.minRequiredClassVersion = info.minRequiredClassVersion;
         this.checkModifiers();
     }
     
@@ -73,7 +67,6 @@ public class AccessorGeneratorMethodProxy extends AccessorGenerator {
         this.targetMethod = info.getTargetMethod();
         this.argTypes = info.getArgTypes();
         this.returnType = info.getReturnType();
-        this.minRequiredClassVersion = info.minRequiredClassVersion;
     }
 
     @Override
@@ -87,7 +80,11 @@ public class AccessorGeneratorMethodProxy extends AccessorGenerator {
         boolean isInterface = Bytecode.hasFlag(this.info.getClassNode(), Opcodes.ACC_INTERFACE);
         boolean isPrivate = Bytecode.hasFlag(this.targetMethod, Opcodes.ACC_PRIVATE);
         int opcode = this.targetIsStatic ? Opcodes.INVOKESTATIC : isInterface ? Opcodes.INVOKEINTERFACE : (
-                isPrivate && minRequiredClassVersion < MixinEnvironment.CompatibilityLevel.JAVA_11.getClassVersion() ? Opcodes.INVOKESPECIAL : Opcodes.INVOKEVIRTUAL
+                // This cast to MixinTargetContext is safe.
+                // This is because `getMixin()` is final, and returns AnnotatedMethodInfo.context.
+                // This field is set in the constructor, and the `super` ctor call in SpecialMethodInfo
+                // (which AccessorInfo is) passes a MixinTargetContext, strictly, from its ctor argument type.
+                isPrivate && ((MixinTargetContext) info.getMixin()).getMinRequiredClassVersion() < MixinEnvironment.CompatibilityLevel.JAVA_11.getClassVersion() ? Opcodes.INVOKESPECIAL : Opcodes.INVOKEVIRTUAL
         );
         method.instructions.add(new MethodInsnNode(opcode, this.info.getClassNode().name, this.targetMethod.name, this.targetMethod.desc, isInterface));
         method.instructions.add(new InsnNode(this.returnType.getOpcode(Opcodes.IRETURN)));

--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorInfo.java
@@ -289,6 +289,12 @@ public class AccessorInfo extends SpecialMethodInfo {
      * method body 
      */
     protected AccessorGenerator generator;
+
+    /**
+     * Minimum required class version for the accessor. Used to determine whether to emit INVOKEVIRTUAL or INVOKESPECIAL
+     * for private method calls, matching javac. See <a href="https://openjdk.org/jeps/181">JEP 181</a>.
+     */
+    protected final int minRequiredClassVersion;
     
     public AccessorInfo(MixinTargetContext mixin, MethodNode method) {
         this(mixin, method, Accessor.class);
@@ -305,6 +311,7 @@ public class AccessorInfo extends SpecialMethodInfo {
         this.targetFieldType = this.initTargetFieldType();
         this.target = this.initTarget();
         this.annotation.visit("target", this.target.toString());
+        this.minRequiredClassVersion = mixin.getMinRequiredClassVersion();
     }
 
     protected AccessorType initType() {

--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorInfo.java
@@ -289,12 +289,6 @@ public class AccessorInfo extends SpecialMethodInfo {
      * method body 
      */
     protected AccessorGenerator generator;
-
-    /**
-     * Minimum required class version for the accessor. Used to determine whether to emit INVOKEVIRTUAL or INVOKESPECIAL
-     * for private method calls, matching javac. See <a href="https://openjdk.org/jeps/181">JEP 181</a>.
-     */
-    protected final int minRequiredClassVersion;
     
     public AccessorInfo(MixinTargetContext mixin, MethodNode method) {
         this(mixin, method, Accessor.class);
@@ -311,7 +305,6 @@ public class AccessorInfo extends SpecialMethodInfo {
         this.targetFieldType = this.initTargetFieldType();
         this.target = this.initTarget();
         this.annotation.visit("target", this.target.toString());
-        this.minRequiredClassVersion = mixin.getMinRequiredClassVersion();
     }
 
     protected AccessorType initType() {

--- a/src/main/java/org/spongepowered/asm/mixin/injection/code/Injector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/code/Injector.java
@@ -445,12 +445,7 @@ public abstract class Injector {
      * @return injected insn node
      */
     protected AbstractInsnNode invokeHandler(InsnList insns, MethodNode handler) {
-        boolean isPrivate = Bytecode.hasFlag(handler, Opcodes.ACC_PRIVATE);
-        boolean isSynthetic = Bytecode.hasFlag(handler, Opcodes.ACC_SYNTHETIC);
-        int invokeOpcode = this.isStatic ? Opcodes.INVOKESTATIC :
-                           this.isInterface ? (isSynthetic && isPrivate ? Opcodes.INVOKESPECIAL : Opcodes.INVOKEINTERFACE) :
-                           isPrivate ? Opcodes.INVOKESPECIAL : Opcodes.INVOKEVIRTUAL;
-        MethodInsnNode insn = new MethodInsnNode(invokeOpcode, this.classNode.name, handler.name, handler.desc, isInterface);
+        MethodInsnNode insn = Bytecode.invokeMethod(this.classNode, handler, this.info.getMixin());
         insns.add(insn);
         this.info.addCallbackInvocation(handler);
         return insn;

--- a/src/main/java/org/spongepowered/asm/mixin/struct/AnnotatedMethodInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/struct/AnnotatedMethodInfo.java
@@ -116,7 +116,7 @@ public class AnnotatedMethodInfo implements IInjectionPointContext {
      * @return the target context
      */
     @Override
-    public final IMixinContext getMixin() {
+    public IMixinContext getMixin() {
         return this.context;
     }
 

--- a/src/main/java/org/spongepowered/asm/mixin/struct/SpecialMethodInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/struct/SpecialMethodInfo.java
@@ -93,4 +93,11 @@ public class SpecialMethodInfo extends AnnotatedMethodInfo {
         return this.methodName;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MixinTargetContext getMixin() {
+        return this.mixin;
+    }
 }

--- a/src/main/java/org/spongepowered/asm/util/Bytecode.java
+++ b/src/main/java/org/spongepowered/asm/util/Bytecode.java
@@ -43,6 +43,8 @@ import org.objectweb.asm.tree.*;
 import org.objectweb.asm.util.CheckClassAdapter;
 import org.objectweb.asm.util.Printer;
 import org.objectweb.asm.util.TraceClassVisitor;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.transformer.MixinTargetContext;
 import org.spongepowered.asm.util.asm.ASM;
 import org.spongepowered.asm.util.asm.MarkerNode;
 import org.spongepowered.asm.util.throwables.SyntheticBridgeException;
@@ -1427,6 +1429,30 @@ public final class Bytecode {
         } else {
             return new LdcInsnNode(intValue);
         }
+    }
+
+    /**
+     * Generates a method instruction for invoking the provided method, in the provided class. The opcode used matches
+     * the behavior of javac for the class version of the provided {@code context}.
+     * @param target class of the method to be invoked
+     * @param method method to invoke
+     * @param context context for the mixin causing this instruction
+     * @return method instruction with the proper opcode
+     */
+    public static MethodInsnNode invokeMethod(ClassNode target, MethodNode method, MixinTargetContext context) {
+        boolean isPrivate = Bytecode.hasFlag(method, Opcodes.ACC_PRIVATE);
+        boolean isInterface = Bytecode.hasFlag(target, Opcodes.ACC_INTERFACE);
+        boolean isStatic = Bytecode.hasFlag(method, Opcodes.ACC_STATIC);
+
+        // With JEP 181, javac now emits INVOKEINTERFACE for interface private methods, and INVOKEVIRTUAL for class private methods
+        MixinEnvironment.CompatibilityLevel requiredCompatLevel = MixinEnvironment.CompatibilityLevel.forClassVersion(context.getMinRequiredClassVersion());
+        boolean supportsNestMateAccess = requiredCompatLevel.supports(LanguageFeatures.NESTING);
+
+        int invokeOpcode = isStatic ? Opcodes.INVOKESTATIC :
+                isPrivate && !supportsNestMateAccess ? Opcodes.INVOKESPECIAL :
+                isInterface ? Opcodes.INVOKEINTERFACE :
+                Opcodes.INVOKEVIRTUAL;
+        return new MethodInsnNode(invokeOpcode, target.name, method.name, method.desc, isInterface);
     }
 
 }


### PR DESCRIPTION
This causes mixin to emit bytecode with INVOKE* instruction matching what javac would emit, based on the class version of an accessor mixin class, for invokers private methods (instead of always emitting INVOKESPECIAL as it currently does).

In practice, this is unlikely to have much of an impact other than changing what any transformer after mixin sees. There are edge cases in which treatment of the two by later transformers may differ or ought to differ, however, so it is smart to both match the javac behavior here, and determine the behavior from the accessor mixin class version.

Having explicit control over the instruction emitted here (aka, being able to define an invoker that always emits INVOKESPECIAL) is distinctly useful for _public_ methods, since it allows creating invokers that will only ever invoke the impl of a method provided in the mixin-ed class, not any impl in a subclass, but that is a larger change that I will leave to a different PR.