### PR TITLE
Fix accessor case sensitivity

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/FabricUtil.java
+++ b/src/main/java/org/spongepowered/asm/mixin/FabricUtil.java
@@ -67,9 +67,14 @@ public final class FabricUtil {
     public static final int COMPATIBILITY_0_17_1 = 17001; // 0.17.1+mixin.0.8.7
 
     /**
+     * Fabric compatibility version 0.17.4
+     */
+    public static final int COMPATIBILITY_0_17_4 = 17004; // 0.17.4+mixin.0.8.7
+
+    /**
      * Latest compatibility version
      */
-    public static final int COMPATIBILITY_LATEST = COMPATIBILITY_0_17_1;
+    public static final int COMPATIBILITY_LATEST = COMPATIBILITY_0_17_4;
 
     public static String getModId(IMixinConfig config) {
         return getModId(config, "(unknown)");

--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorInfo.java
@@ -24,15 +24,9 @@
  */
 package org.spongepowered.asm.mixin.gen;
 
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.MethodNode;
@@ -41,8 +35,8 @@ import org.spongepowered.asm.mixin.gen.throwables.InvalidAccessorException;
 import org.spongepowered.asm.mixin.injection.selectors.ElementNode;
 import org.spongepowered.asm.mixin.injection.selectors.ISelectorContext;
 import org.spongepowered.asm.mixin.injection.selectors.ITargetSelector;
-import org.spongepowered.asm.mixin.injection.selectors.TargetSelector;
 import org.spongepowered.asm.mixin.injection.selectors.ITargetSelector.Configure;
+import org.spongepowered.asm.mixin.injection.selectors.TargetSelector;
 import org.spongepowered.asm.mixin.injection.selectors.TargetSelector.Result;
 import org.spongepowered.asm.mixin.injection.struct.MemberInfo;
 import org.spongepowered.asm.mixin.struct.SpecialMethodInfo;
@@ -52,9 +46,10 @@ import org.spongepowered.asm.util.Annotations;
 import org.spongepowered.asm.util.Bytecode;
 import org.spongepowered.asm.util.asm.MethodNodeEx;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
+import java.lang.annotation.Annotation;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Information about an accessor

--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorInfo.java
@@ -506,7 +506,7 @@ public class AccessorInfo extends SpecialMethodInfo {
      * @return best match
      */
     protected <TNode> TNode findTarget(List<ElementNode<TNode>> nodes) {
-        Result<TNode> result = TargetSelector.<TNode>run(this.target.configure(Configure.ORPHAN), nodes);
+        Result<TNode> result = TargetSelector.<TNode>run(this.mixin, this.target.configure(Configure.ORPHAN), nodes);
 
         try {
             return result.getSingleResult(true);

--- a/src/main/java/org/spongepowered/asm/mixin/gen/InvokerInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/InvokerInfo.java
@@ -104,7 +104,7 @@ class InvokerInfo extends AccessorInfo {
     }
 
     private MethodNode findTargetMethod() {
-        Result<MethodNode> result = TargetSelector.<MethodNode>run(this.target.configure(Configure.ORPHAN),
+        Result<MethodNode> result = TargetSelector.<MethodNode>run(this.mixin, this.target.configure(Configure.ORPHAN),
                 ElementNode.methodList(this.classNode));
 
         try {

--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelector.java
@@ -27,6 +27,7 @@ package org.spongepowered.asm.mixin.injection.selectors;
 import com.google.common.base.Strings;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AnnotationNode;
+import org.spongepowered.asm.mixin.FabricUtil;
 import org.spongepowered.asm.mixin.injection.selectors.ITargetSelectorDynamic.SelectorAnnotation;
 import org.spongepowered.asm.mixin.injection.selectors.ITargetSelectorDynamic.SelectorId;
 import org.spongepowered.asm.mixin.injection.selectors.dynamic.DynamicSelectorDesc;
@@ -47,6 +48,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
@@ -479,10 +481,15 @@ public final class TargetSelector {
 
     private static <TNode> ElementNode<TNode> runSelector(ITargetSelector selector, Iterable<ElementNode<TNode>> nodes,
             List<ElementNode<TNode>> candidates) {
-        List<Map.Entry<ElementNode<TNode>, MatchResult>> matches = StreamSupport.stream(nodes.spliterator(), false)
+        Stream<AbstractMap.SimpleImmutableEntry<ElementNode<TNode>, MatchResult>> stream = StreamSupport.stream(nodes.spliterator(), false)
                 .map(element -> new AbstractMap.SimpleImmutableEntry<>(element, selector.match(element)))
-                .filter(entry -> entry.getValue().isMatch())
-                .sorted(Comparator.<Map.Entry<ElementNode<TNode>, MatchResult>, Boolean>comparing(entry -> entry.getValue().isExactMatch()).reversed())
+                .filter(entry -> entry.getValue().isMatch());
+
+        if (FabricUtil.getCompatibility(mixin) >= FabricUtil.COMPATIBILITY_0_17_4) {
+            stream = stream.sorted(Comparator.<Map.Entry<ElementNode<TNode>, MatchResult>, Boolean>comparing(entry -> entry.getValue().isExactMatch()).reversed());
+        }
+
+        List<Map.Entry<ElementNode<TNode>, MatchResult>> matches = stream
                 .limit(selector.getMaxMatchCount())
                 .collect(Collectors.toList());
 
@@ -495,7 +502,7 @@ public final class TargetSelector {
             candidates.add(match.getKey());
         }
 
-        return matches.isEmpty() || !matches.get(0).getValue().isExactMatch() ? null : matches.get(0).getKey();
+        return matches.stream().filter(entry -> entry.getValue().isExactMatch()).findFirst().map(Map.Entry::getKey).orElse(null);
     }
 
 }

--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelector.java
@@ -496,13 +496,13 @@ public final class TargetSelector {
                 .limit(selector.getMaxMatchCount())
                 .collect(Collectors.toList());
 
+        for (Map.Entry<ElementNode<TNode>, MatchResult> match : matches) {
+            candidates.add(match.getKey());
+        }
+
         if (matches.size() < selector.getMinMatchCount()) {
             throw new SelectorConstraintException(selector, String.format("%s did not match the required number of targets (required=%d, matched=%d)",
                     selector, selector.getMinMatchCount(), matches.size()));
-        }
-
-        for (Map.Entry<ElementNode<TNode>, MatchResult> match : matches) {
-            candidates.add(match.getKey());
         }
 
         return matches.stream().filter(entry -> entry.getValue().isExactMatch()).findFirst().map(Map.Entry::getKey).orElse(null);

--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelector.java
@@ -24,23 +24,7 @@
  */
 package org.spongepowered.asm.mixin.injection.selectors;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.tools.Diagnostic.Kind;
-
+import com.google.common.base.Strings;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.spongepowered.asm.mixin.injection.selectors.ITargetSelectorDynamic.SelectorAnnotation;
@@ -54,7 +38,14 @@ import org.spongepowered.asm.util.Annotations;
 import org.spongepowered.asm.util.asm.IAnnotationHandle;
 import org.spongepowered.asm.util.logging.MessageRouter;
 
-import com.google.common.base.Strings;
+import javax.tools.Diagnostic.Kind;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Utility class for parsing selectors
@@ -486,31 +477,36 @@ public final class TargetSelector {
 
     private static <TNode> ElementNode<TNode> runSelector(ITargetSelector selector, Iterable<ElementNode<TNode>> nodes,
             List<ElementNode<TNode>> candidates) {
-        int matchCount = 0;
-        ElementNode<TNode> exactMatch = null;
-        for (Iterator<ElementNode<TNode>> iterator = nodes.iterator(); iterator.hasNext();) {
-            ElementNode<TNode> element = iterator.next();
-            MatchResult match = selector.match(element);
+        List<ElementNode<TNode>> matches = new ArrayList<>();
+        List<ElementNode<TNode>> exactMatches = new ArrayList<>();
+
+        for (ElementNode<TNode> node : nodes) {
+            MatchResult match = selector.match(node);
             if (match.isMatch()) {
-                matchCount++;
-                if (matchCount > selector.getMaxMatchCount()) {
-                    break;
-                }
-                if (!candidates.contains(element)) {
-                    candidates.add(element);
-                }
-                if (exactMatch == null && match.isExactMatch()) {
-                    exactMatch = element;
+                if (match.isExactMatch()) {
+                    exactMatches.add(node);
+                } else {
+                    matches.add(node);
                 }
             }
         }
-        
+
+        int matchCount = exactMatches.size() + matches.size();
+
         if (matchCount < selector.getMinMatchCount()) {
             throw new SelectorConstraintException(selector, String.format("%s did not match the required number of targets (required=%d, matched=%d)",
                     selector, selector.getMinMatchCount(), matchCount));
         }
 
-        return exactMatch;
+        int addedCount;
+        for (addedCount = 0; addedCount < exactMatches.size() && addedCount < selector.getMaxMatchCount(); addedCount++) {
+            candidates.add(exactMatches.get(addedCount));
+        }
+        for (; addedCount < exactMatches.size() + matches.size() && addedCount < selector.getMaxMatchCount(); addedCount++) {
+            candidates.add(matches.get(addedCount - exactMatches.size()));
+        }
+
+        return exactMatches.isEmpty() ? null : exactMatches.get(0);
     }
 
 }

--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelector.java
@@ -33,6 +33,7 @@ import org.spongepowered.asm.mixin.injection.selectors.ITargetSelectorDynamic.Se
 import org.spongepowered.asm.mixin.injection.selectors.dynamic.DynamicSelectorDesc;
 import org.spongepowered.asm.mixin.injection.selectors.throwables.SelectorConstraintException;
 import org.spongepowered.asm.mixin.injection.struct.MemberInfo;
+import org.spongepowered.asm.mixin.refmap.IMixinContext;
 import org.spongepowered.asm.mixin.throwables.MixinError;
 import org.spongepowered.asm.mixin.throwables.MixinException;
 import org.spongepowered.asm.util.Annotations;
@@ -445,32 +446,34 @@ public final class TargetSelector {
     
     /**
      * Run query on supplied target nodes
-     * 
+     *
+     * @param mixin context
      * @param selector Target selector
      * @param nodes Node collection to enumerate
      * @param <TNode> Node type
      * @return query result
      */
-    public static <TNode> Result<TNode> run(ITargetSelector selector, Iterable<ElementNode<TNode>> nodes) {
+    public static <TNode> Result<TNode> run(IMixinContext mixin, ITargetSelector selector, Iterable<ElementNode<TNode>> nodes) {
         List<ElementNode<TNode>> candidates = new ArrayList<ElementNode<TNode>>();
-        ElementNode<TNode> exactMatch = TargetSelector.runSelector(selector, nodes, candidates);
+        ElementNode<TNode> exactMatch = TargetSelector.runSelector(mixin, selector, nodes, candidates);
         return new Result<TNode>(exactMatch, candidates);
     }
     
     /**
      * Run query on supplied target nodes
-     * 
+     *
+     * @param mixin context
      * @param selector Target selector
      * @param nodes Node collection to enumerate
      * @param <TNode> Node type
      * @return query result
      */
-    public static <TNode> Result<TNode> run(Iterable<ITargetSelector> selector, Iterable<ElementNode<TNode>> nodes) {
+    public static <TNode> Result<TNode> run(IMixinContext mixin, Iterable<ITargetSelector> selector, Iterable<ElementNode<TNode>> nodes) {
         ElementNode<TNode> exactMatch = null;
         List<ElementNode<TNode>> candidates = new ArrayList<ElementNode<TNode>>();
         
         for (ITargetSelector target : selector) {
-            ElementNode<TNode> selectorExactMatch = TargetSelector.runSelector(target, nodes, candidates);
+            ElementNode<TNode> selectorExactMatch = TargetSelector.runSelector(mixin, target, nodes, candidates);
             if (exactMatch == null) {
                 exactMatch = selectorExactMatch;
             }
@@ -479,7 +482,7 @@ public final class TargetSelector {
         return new Result<TNode>(exactMatch, candidates);
     }
 
-    private static <TNode> ElementNode<TNode> runSelector(ITargetSelector selector, Iterable<ElementNode<TNode>> nodes,
+    private static <TNode> ElementNode<TNode> runSelector(IMixinContext mixin, ITargetSelector selector, Iterable<ElementNode<TNode>> nodes,
             List<ElementNode<TNode>> candidates) {
         Stream<AbstractMap.SimpleImmutableEntry<ElementNode<TNode>, MatchResult>> stream = StreamSupport.stream(nodes.spliterator(), false)
                 .map(element -> new AbstractMap.SimpleImmutableEntry<>(element, selector.match(element)))

--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelector.java
@@ -46,6 +46,8 @@ import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Utility class for parsing selectors
@@ -477,36 +479,23 @@ public final class TargetSelector {
 
     private static <TNode> ElementNode<TNode> runSelector(ITargetSelector selector, Iterable<ElementNode<TNode>> nodes,
             List<ElementNode<TNode>> candidates) {
-        List<ElementNode<TNode>> matches = new ArrayList<>();
-        List<ElementNode<TNode>> exactMatches = new ArrayList<>();
+        List<Map.Entry<ElementNode<TNode>, MatchResult>> matches = StreamSupport.stream(nodes.spliterator(), false)
+                .map(element -> new AbstractMap.SimpleImmutableEntry<>(element, selector.match(element)))
+                .filter(entry -> entry.getValue().isMatch())
+                .sorted(Comparator.<Map.Entry<ElementNode<TNode>, MatchResult>, Boolean>comparing(entry -> entry.getValue().isExactMatch()).reversed())
+                .limit(selector.getMaxMatchCount())
+                .collect(Collectors.toList());
 
-        for (ElementNode<TNode> node : nodes) {
-            MatchResult match = selector.match(node);
-            if (match.isMatch()) {
-                if (match.isExactMatch()) {
-                    exactMatches.add(node);
-                } else {
-                    matches.add(node);
-                }
-            }
-        }
-
-        int matchCount = exactMatches.size() + matches.size();
-
-        if (matchCount < selector.getMinMatchCount()) {
+        if (matches.size() < selector.getMinMatchCount()) {
             throw new SelectorConstraintException(selector, String.format("%s did not match the required number of targets (required=%d, matched=%d)",
-                    selector, selector.getMinMatchCount(), matchCount));
+                    selector, selector.getMinMatchCount(), matches.size()));
         }
 
-        int addedCount;
-        for (addedCount = 0; addedCount < exactMatches.size() && addedCount < selector.getMaxMatchCount(); addedCount++) {
-            candidates.add(exactMatches.get(addedCount));
-        }
-        for (; addedCount < exactMatches.size() + matches.size() && addedCount < selector.getMaxMatchCount(); addedCount++) {
-            candidates.add(matches.get(addedCount - exactMatches.size()));
+        for (Map.Entry<ElementNode<TNode>, MatchResult> match : matches) {
+            candidates.add(match.getKey());
         }
 
-        return exactMatches.isEmpty() ? null : exactMatches.get(0);
+        return matches.isEmpty() || !matches.get(0).getValue().isExactMatch() ? null : matches.get(0).getKey();
     }
 
 }

--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelectors.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelectors.java
@@ -269,7 +269,7 @@ public class TargetSelectors implements Iterable<TargetSelectors.SelectedMethod>
                 }
                 
                 recursed = true;
-                Result<AbstractInsnNode> result = TargetSelector.run(next, ElementNode.dynamicInsnList(target.getMethod().instructions));
+                Result<AbstractInsnNode> result = TargetSelector.run(this.mixin, next, ElementNode.dynamicInsnList(target.getMethod().instructions));
                 iter.remove();
                 for (ElementNode<AbstractInsnNode> candidate : result.candidates) {
                     if (candidate.getInsn().getOpcode() != Opcodes.INVOKEDYNAMIC) {


### PR DESCRIPTION
This only adds prioritizing exact match.

This does NOT only allow the first character to be case-insensitive. I had trouble doing that because I needed to add a version gate and get the context in `MemberInfo#matches`, which became very ugly.