### PR TITLE
Improvement: Allow multiple `@At`s and `@Slice`s in all injectors.

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/injection/ModifyArg.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/ModifyArg.java
@@ -106,22 +106,23 @@ public @interface ModifyArg {
     public Desc[] target() default {};
     
     /**
-     * A {@link Slice} annotation which describes the method bisection used in
-     * the {@link #at} query for this injector.
+     * Array of {@link Slice} annotations which describe the method bisections
+     * used in the {@link #at} queries for this injector.
      * 
-     * @return slice
+     * @return slices
      */
-    public Slice slice() default @Slice;
+    public Slice[] slice() default {};
 
     /**
-     * An {@link At} annotation which describes the {@link InjectionPoint} in
-     * the target method. The specified {@link InjectionPoint} <i>must only</i>
-     * return {@link org.objectweb.asm.tree.MethodInsnNode} instances
-     * and an exception will be thrown if this is not the case.
+     * Array of {@link At} annotations which describe the
+     * {@link InjectionPoint}s in the target method. The specified
+     * {@link InjectionPoint}s <i>must only</i> return
+     * {@link org.objectweb.asm.tree.MethodInsnNode} instances and an exception
+     * will be thrown if this is not the case.
      * 
-     * @return {@link At} which identifies the target method invocation
+     * @return {@link At}s which identify the target method invocation
      */
-    public At at();
+    public At[] at();
     
     /**
      * <p>Gets the argument index on the target to set. It is not necessary to

--- a/src/main/java/org/spongepowered/asm/mixin/injection/ModifyArgs.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/ModifyArgs.java
@@ -97,22 +97,23 @@ public @interface ModifyArgs {
     public Desc[] target() default {};
     
     /**
-     * A {@link Slice} annotation which describes the method bisection used in
-     * the {@link #at} query for this injector.
+     * Array of {@link Slice} annotations which describe the method bisections
+     * used in the {@link #at} queries for this injector.
      * 
-     * @return slice
+     * @return slices
      */
-    public Slice slice() default @Slice;
+    public Slice[] slice() default {};
 
     /**
-     * An {@link At} annotation which describes the {@link InjectionPoint} in
-     * the target method. The specified {@link InjectionPoint} <i>must only</i>
-     * return {@link org.objectweb.asm.tree.MethodInsnNode} instances
-     * and an exception will be thrown if this is not the case.
-     * 
-     * @return {@link At} which identifies the target method invocation
+     * Array of {@link At} annotations which describe the
+     * {@link InjectionPoint}s in the target method. The specified
+     * {@link InjectionPoint}s <i>must only</i> return
+     * {@link org.objectweb.asm.tree.MethodInsnNode} instances and an exception
+     * will be thrown if this is not the case.
+     *
+     * @return {@link At}s which identify the target method invocation
      */
-    public At at();
+    public At[] at();
     
     /**
      * By default, the annotation processor will attempt to locate an

--- a/src/main/java/org/spongepowered/asm/mixin/injection/ModifyVariable.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/ModifyVariable.java
@@ -121,21 +121,21 @@ public @interface ModifyVariable {
     public Desc[] target() default {};
     
     /**
-     * A {@link Slice} annotation which describes the method bisection used in
-     * the {@link #at} query for this injector.
+     * Array of {@link Slice} annotations which describe the method bisections
+     * used in the {@link #at} queries for this injector.
      * 
-     * @return slice
+     * @return slices
      */
-    public Slice slice() default @Slice;
+    public Slice[] slice() default {};
 
     /**
-     * An {@link At} annotation which describes the {@link InjectionPoint} in
-     * the target method.
+     * Array of {@link At} annotations which describe the {@link InjectionPoint}s
+     * in the target method.
      * 
-     * @return {@link At} which identifies the location to inject inside the
+     * @return {@link At}s which identify the locations to inject inside the
      *      target method.
      */
-    public At at();
+    public At[] at();
     
     /**
      * When creating a {@link ModifyVariable} callback, you may wish to first

--- a/src/main/java/org/spongepowered/asm/mixin/injection/Redirect.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/Redirect.java
@@ -337,22 +337,20 @@ public @interface Redirect {
     public Desc[] target() default {};
     
     /**
-     * A {@link Slice} annotation which describes the method bisection used in
-     * the {@link #at} query for this injector.
+     * Array of {@link Slice} annotations which describe the method bisections
+     * used in the {@link #at} queries for this injector.
      * 
-     * @return slice
+     * @return slices
      */
-    public Slice slice() default @Slice;
+    public Slice[] slice() default {};
 
     /**
-     * An {@link At} annotation which describes the {@link InjectionPoint} in
-     * the target method. The specified {@link InjectionPoint} <i>must only</i>
-     * return {@link org.objectweb.asm.tree.MethodInsnNode} and an
-     * exception will be thrown if this is not the case.
+     * Array of {@link At} annotations which describe the {@link InjectionPoint}s
+     * in the target method.
      * 
-     * @return {@link At} which identifies the target method invocation
+     * @return {@link At}s which identify the target instructions
      */
-    public At at();
+    public At[] at();
 
     /**
      * By default, the annotation processor will attempt to locate an


### PR DESCRIPTION
This is a source-level break for Kotlin and Scala mixins, but imo that shouldn't be a problem since they're more or less unsupported.