### PR TITLE
Make accessors visible in exported class

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGenerator.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGenerator.java
@@ -78,7 +78,7 @@ public abstract class AccessorGenerator {
      */
     protected final MethodNode createMethod(int maxLocals, int maxStack) {
         MethodNode method = this.info.getMethod();
-        MethodNode accessor = new MethodNode(ASM.API_VERSION, (method.access & ~Opcodes.ACC_ABSTRACT) | Opcodes.ACC_SYNTHETIC, method.name,
+        MethodNode accessor = new MethodNode(ASM.API_VERSION, method.access & ~Opcodes.ACC_ABSTRACT, method.name,
                 method.desc, null, null);
         accessor.visibleAnnotations = new ArrayList<AnnotationNode>();
         accessor.visibleAnnotations.add(this.info.getAnnotationNode());

--- a/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGenerator.java
+++ b/src/main/java/org/spongepowered/asm/mixin/gen/AccessorGenerator.java
@@ -78,7 +78,11 @@ public abstract class AccessorGenerator {
      */
     protected final MethodNode createMethod(int maxLocals, int maxStack) {
         MethodNode method = this.info.getMethod();
-        MethodNode accessor = new MethodNode(ASM.API_VERSION, method.access & ~Opcodes.ACC_ABSTRACT, method.name,
+        int access = method.access & ~Opcodes.ACC_ABSTRACT;
+        if (this.info.isStatic()) {
+            access |= Opcodes.ACC_SYNTHETIC;
+        }
+        MethodNode accessor = new MethodNode(ASM.API_VERSION, access, method.name,
                 method.desc, null, null);
         accessor.visibleAnnotations = new ArrayList<AnnotationNode>();
         accessor.visibleAnnotations.add(this.info.getAnnotationNode());


### PR DESCRIPTION
This should make accessors generated with `@Accessor` and `@Invoker` visible in decompiled mixin exports.