### PR TITLE
Avoid useless no such method exception log

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/PluginHandle.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/PluginHandle.java
@@ -120,8 +120,7 @@ class PluginHandle {
             if (nonLegacy.getDeclaringClass() == IMixinConfigPlugin.class) {
                 try {
                     legacyMethod = pluginClass.getMethod(applyName, String.class, org.spongepowered.asm.lib.tree.ClassNode.class, String.class, IMixinInfo.class);
-                } catch (NoSuchMethodException e) {
-                    PluginHandle.logger.catching(e);
+                } catch (NoSuchMethodException ignored) {
                 }
             }
         } catch (Exception unexpectedEx) {

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/PluginHandle.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/PluginHandle.java
@@ -121,6 +121,7 @@ class PluginHandle {
                 try {
                     legacyMethod = pluginClass.getMethod(applyName, String.class, org.spongepowered.asm.lib.tree.ClassNode.class, String.class, IMixinInfo.class);
                 } catch (NoSuchMethodException ignored) {
+                    // No legacy method found, nothing to do
                 }
             }
         } catch (Exception unexpectedEx) {


### PR DESCRIPTION
If a Mixin plugin doesn't override the `preApply` or `postApply` methods and does not have the legacy methods Mixin currently logs the `NoSuchMethodException` as an error even though nothing is actually wrong.