### PR TITLE
Feature/lambda selection

### DIFF
--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixin.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixin.java
@@ -499,6 +499,11 @@ class AnnotatedMixin implements IMixinContext, IAnnotatedElement {
     }
 
     @Override
+    public boolean isCompileTime() {
+        return true;
+    }
+
+    @Override
     public IAnnotationHandle getAnnotation(Class<? extends Annotation> annotationClass) {
         return AnnotationHandle.of(this.mixin, annotationClass);
     }

--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixin.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixin.java
@@ -288,7 +288,7 @@ class AnnotatedMixin implements IMixinContext, IAnnotatedElement {
     private void addSoftTarget(TypeHandle type, String reference) {
         ObfuscationData<String> obfClassData = this.obf.getDataProvider().getObfClass(type);
         if (!obfClassData.isEmpty()) {
-            this.obf.getReferenceManager().addClassMapping(this.classRef, reference, obfClassData);
+            this.obf.getReferenceManager().addMapping(this.classRef, reference, obfClassData);
         }
 
         this.addTarget(type);

--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerAccessor.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerAccessor.java
@@ -326,7 +326,7 @@ class AnnotatedMixinElementHandlerAccessor extends AnnotatedMixinElementHandler 
         }
 
         ObfuscationData<String> obfData = this.obf.getDataProvider().getObfClass(elem.getAnnotationValue().replace('.', '/'));
-        this.obf.getReferenceManager().addClassMapping(this.mixin.getClassRef(), elem.getAnnotationValue(), obfData);
+        this.obf.getReferenceManager().addMapping(this.mixin.getClassRef(), elem.getAnnotationValue(), obfData);
     }
 
     private String getAccessorTargetName(AnnotatedElementAccessor elem) {

--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerInjector.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerInjector.java
@@ -44,6 +44,7 @@ import org.spongepowered.asm.mixin.injection.selectors.ITargetSelectorRemappable
 import org.spongepowered.asm.mixin.injection.selectors.InvalidSelectorException;
 import org.spongepowered.asm.mixin.injection.selectors.TargetSelector;
 import org.spongepowered.asm.mixin.injection.struct.InjectionPointData;
+import org.spongepowered.asm.mixin.injection.struct.MemberInfo;
 import org.spongepowered.asm.mixin.refmap.IMixinContext;
 import org.spongepowered.asm.obfuscation.mapping.common.MappingField;
 import org.spongepowered.asm.obfuscation.mapping.common.MappingMethod;
@@ -199,6 +200,7 @@ class AnnotatedMixinElementHandlerInjector extends AnnotatedMixinElementHandler 
     private void registerInjectorTarget(AnnotatedElementInjector elem, String reference, ITargetSelector targetSelector, String subject) {
         try {
             targetSelector.validate();
+            targetSelector.validateNext();
         } catch (InvalidSelectorException ex) {
             elem.printMessage(this.ap, MessageType.TARGET_SELECTOR_VALIDATION, ex.getMessage());
         }
@@ -208,23 +210,32 @@ class AnnotatedMixinElementHandlerInjector extends AnnotatedMixinElementHandler 
         }
         
         ITargetSelectorByName targetMember = (ITargetSelectorByName)targetSelector;
-        if (targetMember.getName() == null) {
-            return;
-        }
-        
-        if (targetMember.getDesc() != null) {
+
+        if (targetMember.getName() != null && targetMember.getDesc() != null) {
             this.validateReferencedTarget(elem, reference, targetMember, subject);
         }
 
-        if (targetSelector instanceof ITargetSelectorRemappable && elem.shouldRemap()) {
+        if (targetSelector instanceof ITargetSelectorRemappable) {
             this.registerInjector(elem, reference, (ITargetSelectorRemappable) targetMember);
         }
     }
 
     private void registerInjector(AnnotatedElementInjector elem, String reference, ITargetSelectorRemappable targetMember) {
         String targetName = elem + " target " + targetMember.getName();
-        ObfuscationData<String> remapped = this.remapTarget(elem, reference, targetMember, targetName);
-        if (remapped == null) {
+        ObfuscationData<String> remapped;
+        if (elem.shouldRemap() && targetMember.getName() != null) {
+            remapped = this.remapTarget(elem, reference, targetMember, targetName);
+            if (remapped == null) {
+                return;
+            }
+        } else {
+            remapped = new ObfuscationData<>();
+        }
+
+        if (targetMember instanceof MemberInfo) {
+            // Need to try remapping the nested selectors, even if remap is false
+            remapped = this.remapMemberInfo((MemberInfo) targetMember, remapped);
+        } else if (!elem.shouldRemap()) {
             return;
         }
 
@@ -316,6 +327,39 @@ class AnnotatedMixinElementHandlerInjector extends AnnotatedMixinElementHandler 
                     this.ap, MessageType.INJECTOR_MAPPING_CONFLICT,
                     "Multi-target reference conflict for " + targetName + ": " + members
             );
+        }
+
+        return result;
+    }
+
+    private ObfuscationData<String> remapMemberInfo(MemberInfo targetMember, ObfuscationData<String> rootNames) {
+        MemberInfo next = (MemberInfo) targetMember.next();
+        if (next == null) {
+            return rootNames;
+        }
+
+        ObfuscationData<String> result = new ObfuscationData<>();
+        for (ObfuscationEnvironment env : this.obf.getEnvironments()) {
+            boolean needsMapping = false;
+            String rootName = rootNames.get(env.getType());
+            if (rootName == null) {
+                rootName = targetMember.headToString();
+            } else {
+                needsMapping = true;
+            }
+
+            MemberInfo remappedNext = next.remapNestedUsing(new ObfuscationEnvironmentRemapper(env, this.obf.getDataProvider()));
+            if (remappedNext == null) {
+                // No change
+                remappedNext = next;
+            } else {
+                needsMapping = true;
+            }
+
+            if (needsMapping) {
+                String remapped = rootName + " ->" + targetMember.recurseDepthToString() + ' ' + remappedNext;
+                result.put(env.getType(), remapped);
+            }
         }
 
         return result;

--- a/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerInjector.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/AnnotatedMixinElementHandlerInjector.java
@@ -25,7 +25,10 @@
 package org.spongepowered.tools.obfuscation;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -44,6 +47,7 @@ import org.spongepowered.asm.mixin.injection.struct.InjectionPointData;
 import org.spongepowered.asm.mixin.refmap.IMixinContext;
 import org.spongepowered.asm.obfuscation.mapping.common.MappingField;
 import org.spongepowered.asm.obfuscation.mapping.common.MappingMethod;
+import org.spongepowered.asm.util.NameAndDesc;
 import org.spongepowered.asm.util.asm.IAnnotationHandle;
 import org.spongepowered.tools.obfuscation.ReferenceManager.ReferenceConflictException;
 import org.spongepowered.tools.obfuscation.ext.SpecialPackages;
@@ -211,81 +215,110 @@ class AnnotatedMixinElementHandlerInjector extends AnnotatedMixinElementHandler 
         if (targetMember.getDesc() != null) {
             this.validateReferencedTarget(elem, reference, targetMember, subject);
         }
-        
+
         if (targetSelector instanceof ITargetSelectorRemappable && elem.shouldRemap()) {
-            for (TypeHandle target : this.mixin.getTargets()) {
-                if (!this.registerInjector(elem, reference, (ITargetSelectorRemappable)targetMember, target)) {
-                    break;
-                }
-            }
+            this.registerInjector(elem, reference, (ITargetSelectorRemappable) targetMember);
         }
     }
 
-    private boolean registerInjector(AnnotatedElementInjector elem, String reference, ITargetSelectorRemappable targetMember, TypeHandle target) {
-        String desc = target.findDescriptor(targetMember);
-        if (desc == null) {
-            MessageType messageType = this.mixin.isMultiTarget() ? MessageType.MISSING_INJECTOR_DESC_MULTITARGET
-                    : MessageType.MISSING_INJECTOR_DESC_SINGLETARGET;
-            if (target.isSimulated()) {
-                elem.printMessage(this.ap, MessageType.MISSING_INJECTOR_DESC_SIMULATED, elem + " target '" + reference
-                        + "' in @Pseudo mixin will not be obfuscated");
-            } else if (target.isImaginary()) {
-                elem.printMessage(this.ap, messageType, elem + " target requires method signature because enclosing type information for "
-                        + target + " is unavailable");
-            } else if (!targetMember.isInitialiser()) {
-                elem.printMessage(this.ap, messageType, "Unable to determine descriptor for " + elem + " target method");
-            }
-            return true;
-        }
-        
+    private void registerInjector(AnnotatedElementInjector elem, String reference, ITargetSelectorRemappable targetMember) {
         String targetName = elem + " target " + targetMember.getName();
-        MappingMethod targetMethod = target.getMappingMethod(targetMember.getName(), desc);
-        ObfuscationData<MappingMethod> obfData = this.obf.getDataProvider().getObfMethod(targetMethod);
-        if (obfData.isEmpty()) {
-            if (target.isSimulated()) {
-                obfData = this.obf.getDataProvider().getRemappedMethod(targetMethod);
-            } else if (targetMember.isClassInitialiser()) {
-                return true;
-            } else {
-                elem.addMessage(targetMember.isConstructor() ? MessageType.NO_OBFDATA_FOR_CTOR : MessageType.NO_OBFDATA_FOR_TARGET,
-                        "Unable to locate obfuscation mapping for " + targetName, elem.getElement(), elem.getAnnotation());
-                return false;
-            }
+        ObfuscationData<String> remapped = this.remapTarget(elem, reference, targetMember, targetName);
+        if (remapped == null) {
+            return;
         }
-        
+
         IReferenceManager refMaps = this.obf.getReferenceManager();
         try {
-            // If the original owner is unspecified, and the mixin is multi-target, we strip the owner from the obf mappings
-            if ((targetMember.getOwner() == null && this.mixin.isMultiTarget()) || target.isSimulated()) {
-                obfData = AnnotatedMixinElementHandler.<MappingMethod>stripOwnerData(obfData);
-            }
-            refMaps.addMethodMapping(this.classRef, reference, obfData);
+            refMaps.addMapping(this.classRef, reference, remapped);
         } catch (ReferenceConflictException ex) {
             String conflictType = this.mixin.isMultiTarget() ? "Multi-target" : "Target";
-            
-            if (elem.hasCoerceArgument() && targetMember.getOwner() == null && targetMember.getDesc() == null) {
-                ITargetSelector oldMember = TargetSelector.parse(ex.getOld(), elem);
-                ITargetSelector newMember = TargetSelector.parse(ex.getNew(), elem);
-                String oldName = oldMember instanceof ITargetSelectorByName ? ((ITargetSelectorByName)oldMember).getName() : oldMember.toString();
-                String newName = newMember instanceof ITargetSelectorByName ? ((ITargetSelectorByName)newMember).getName() : newMember.toString();
-                if (oldName != null && oldName.equals(newName)) {
-                    obfData = AnnotatedMixinElementHandler.<MappingMethod>stripDescriptors(obfData);
-                    refMaps.setAllowConflicts(true);
-                    refMaps.addMethodMapping(this.classRef, reference, obfData);
-                    refMaps.setAllowConflicts(false);
 
-                    // This is bad because in notch mappings, using the bare target name might cause everything to explode
-                    elem.printMessage(this.ap, MessageType.BARE_REFERENCE, "Coerced " + conflictType + " reference has conflicting descriptors for "
-                            + targetName + ": Storing bare references " + obfData.values() + " in refMap");
-                    return true;
-                }
-            }
-            
             elem.printMessage(this.ap, MessageType.INJECTOR_MAPPING_CONFLICT, conflictType + " reference conflict for " + targetName + ": "
                     + reference + " -> " + ex.getNew() + " previously defined as " + ex.getOld());
         }
-        
-        return true;
+    }
+
+    private ObfuscationData<String> remapTarget(AnnotatedElementInjector elem, String reference, ITargetSelectorRemappable targetMember, String targetName) {
+        ObfuscationData<Set<NameAndDesc>> remapped = new ObfuscationData<>();
+        for (ObfuscationEnvironment env : this.obf.getEnvironments()) {
+            remapped.put(env.getType(), new HashSet<>());
+        }
+
+        for (TypeHandle target : this.mixin.getTargets()) {
+            String desc = target.findDescriptor(targetMember);
+            if (desc == null) {
+                MessageType messageType = this.mixin.isMultiTarget() ? MessageType.MISSING_INJECTOR_DESC_MULTITARGET
+                        : MessageType.MISSING_INJECTOR_DESC_SINGLETARGET;
+                if (target.isSimulated()) {
+                    elem.printMessage(this.ap, MessageType.MISSING_INJECTOR_DESC_SIMULATED, elem + " target '" + reference
+                            + "' in @Pseudo mixin will not be obfuscated");
+                } else if (target.isImaginary()) {
+                    elem.printMessage(this.ap, messageType, elem + " target requires method signature because enclosing type information for "
+                            + target + " is unavailable");
+                } else if (!targetMember.isInitialiser()) {
+                    elem.printMessage(this.ap, messageType, "Unable to determine descriptor for " + elem + " target method");
+                }
+                continue;
+            }
+
+            MappingMethod targetMethod = target.getMappingMethod(targetMember.getName(), desc);
+            ObfuscationData<MappingMethod> obfData = this.obf.getDataProvider().getObfMethod(targetMethod);
+            if (obfData.isEmpty()) {
+                if (target.isSimulated()) {
+                    obfData = this.obf.getDataProvider().getRemappedMethod(targetMethod);
+                } else if (targetMember.isClassInitialiser()) {
+                    continue;
+                } else {
+                    elem.addMessage(targetMember.isConstructor() ? MessageType.NO_OBFDATA_FOR_CTOR : MessageType.NO_OBFDATA_FOR_TARGET,
+                            "Unable to locate obfuscation mapping for " + targetName, elem.getElement(), elem.getAnnotation());
+                    return null;
+                }
+            }
+
+            if ((targetMember.getOwner() == null && this.mixin.isMultiTarget()) || target.isSimulated()) {
+                obfData = AnnotatedMixinElementHandler.stripOwnerData(obfData);
+            }
+
+            for (ObfuscationEnvironment env : this.obf.getEnvironments()) {
+                MappingMethod mapping = obfData.get(env.getType());
+                String name = mapping.getSimpleName();
+                if (mapping.getOwner() != null) {
+                    name = 'L' + mapping.getOwner() + ';' + name;
+                }
+                remapped.get(env.getType()).add(new NameAndDesc(name, mapping.getDesc()));
+            }
+        }
+
+        ObfuscationData<String> result = new ObfuscationData<>();
+        for (ObfuscationEnvironment env : this.obf.getEnvironments()) {
+            Set<NameAndDesc> members = remapped.get(env.getType());
+            if (members.size() == 1) {
+                NameAndDesc member = members.iterator().next();
+                result.put(env.getType(), member.name + member.desc);
+                continue;
+            }
+
+            if (elem.hasCoerceArgument() && targetMember.getOwner() == null && targetMember.getDesc() == null) {
+                Set<String> names = members.stream().map(it -> it.name).collect(Collectors.toSet());
+                if (names.size() == 1) {
+                    String name = names.iterator().next();
+                    result.put(env.getType(), name);
+
+                    // This is bad because in notch mappings, using the bare target name might cause everything to explode
+                    elem.printMessage(this.ap, MessageType.BARE_REFERENCE, "Coerced Multi-target reference has conflicting descriptors for "
+                            + targetName + ": Storing bare reference " + name + " in refMap");
+                }
+                continue;
+            }
+
+            elem.printMessage(
+                    this.ap, MessageType.INJECTOR_MAPPING_CONFLICT,
+                    "Multi-target reference conflict for " + targetName + ": " + members
+            );
+        }
+
+        return result;
     }
 
     /**
@@ -357,7 +390,7 @@ class AnnotatedMixinElementHandlerInjector extends AnnotatedMixinElementHandler 
                 }
             }
             
-            this.obf.getReferenceManager().addClassMapping(this.classRef, reference, mappings);
+            this.obf.getReferenceManager().addMapping(this.classRef, reference, mappings);
         }
         
         elem.notifyRemapped();

--- a/src/ap/java/org/spongepowered/tools/obfuscation/ObfuscationEnvironment.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/ObfuscationEnvironment.java
@@ -257,6 +257,10 @@ public abstract class ObfuscationEnvironment implements IObfuscationEnvironment 
      */
     @Override
     public ITargetSelectorRemappable remapDescriptor(ITargetSelectorRemappable method) {
+        if (!this.initMappings()) {
+            return null;
+        }
+
         boolean transformed = false;
         
         String owner = method.getOwner();
@@ -289,6 +293,10 @@ public abstract class ObfuscationEnvironment implements IObfuscationEnvironment 
      */
     @Override
     public String remapDescriptor(String desc) {
+        if (!this.initMappings()) {
+            return desc;
+        }
+
         String newDesc = ObfuscationUtil.mapDescriptor(desc, this.remapper);
         return newDesc != null ? newDesc : desc;
     }

--- a/src/ap/java/org/spongepowered/tools/obfuscation/ObfuscationEnvironmentRemapper.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/ObfuscationEnvironmentRemapper.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.tools.obfuscation;
+
+import org.spongepowered.asm.mixin.extensibility.IRemapper;
+import org.spongepowered.asm.mixin.injection.struct.MemberInfo;
+import org.spongepowered.asm.obfuscation.mapping.common.MappingField;
+import org.spongepowered.asm.obfuscation.mapping.common.MappingMethod;
+import org.spongepowered.tools.obfuscation.interfaces.IObfuscationDataProvider;
+
+class ObfuscationEnvironmentRemapper implements IRemapper {
+    private final ObfuscationEnvironment env;
+    private final IObfuscationDataProvider dataProvider;
+
+    public ObfuscationEnvironmentRemapper(ObfuscationEnvironment env, IObfuscationDataProvider dataProvider) {
+        this.env = env;
+        this.dataProvider = dataProvider;
+    }
+
+    @Override
+    public String mapMethodName(String owner, String name, String desc) {
+        MappingMethod remapped = this.dataProvider.getObfMethodRecursive(new MemberInfo(name, owner, desc)).get(this.env.getType());
+        if (remapped != null) {
+            return remapped.getSimpleName();
+        }
+        return name;
+    }
+
+    @Override
+    public String mapFieldName(String owner, String name, String desc) {
+        MappingField remapped = this.dataProvider.getObfFieldRecursive(new MemberInfo(name, owner, desc)).get(this.env.getType());
+        if (remapped != null) {
+            return remapped.getSimpleName();
+        }
+        return name;
+    }
+
+    @Override
+    public String map(String typeName) {
+        String remapped = this.dataProvider.getObfClass(typeName).get(this.env.getType());
+        if (remapped != null) {
+            return remapped;
+        }
+        return typeName;
+    }
+
+    @Override
+    public String unmap(String typeName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String mapDesc(String desc) {
+        return this.env.remapDescriptor(desc);
+    }
+
+    @Override
+    public String unmapDesc(String desc) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/ap/java/org/spongepowered/tools/obfuscation/ReferenceManager.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/ReferenceManager.java
@@ -246,9 +246,9 @@ public class ReferenceManager implements IReferenceManager {
      *      org.spongepowered.tools.obfuscation.ObfuscationData)
      */
     @Override
-    public void addClassMapping(String className, String reference, ObfuscationData<String> obfClassData) {
+    public void addMapping(String className, String reference, ObfuscationData<String> obfData) {
         for (ObfuscationEnvironment env : this.environments) {
-            String remapped = obfClassData.get(env.getType());
+            String remapped = obfData.get(env.getType());
             if (remapped != null) {
                 this.addMapping(env.getType(), className, reference, remapped);
             }

--- a/src/ap/java/org/spongepowered/tools/obfuscation/interfaces/IReferenceManager.java
+++ b/src/ap/java/org/spongepowered/tools/obfuscation/interfaces/IReferenceManager.java
@@ -100,12 +100,12 @@ public interface IReferenceManager {
             ObfuscationData<MappingField> obfFieldData);
 
     /**
-     * Adds a class mapping to the internal refmap
+     * Adds an arbitrary mapping to the internal refmap
      * 
      * @param className Mixin class name which owns the refmap entry
      * @param reference Original reference, as it appears in the annotation
-     * @param obfClassData Class obf names
+     * @param obfData Obf strings
      */
-    public abstract void addClassMapping(String className, String reference, ObfuscationData<String> obfClassData);
+    public abstract void addMapping(String className, String reference, ObfuscationData<String> obfData);
 
 }

--- a/src/main/java/org/spongepowered/asm/mixin/FabricUtil.java
+++ b/src/main/java/org/spongepowered/asm/mixin/FabricUtil.java
@@ -72,9 +72,14 @@ public final class FabricUtil {
     public static final int COMPATIBILITY_0_17_4 = 17004; // 0.17.4+mixin.0.8.7
 
     /**
+     * Fabric compatibility version 0.17.5
+     */
+    public static final int COMPATIBILITY_0_17_5 = 17005; // 0.17.5+mixin.0.8.7
+
+    /**
      * Latest compatibility version
      */
-    public static final int COMPATIBILITY_LATEST = COMPATIBILITY_0_17_4;
+    public static final int COMPATIBILITY_LATEST = COMPATIBILITY_0_17_5;
 
     public static String getModId(IMixinConfig config) {
         return getModId(config, "(unknown)");

--- a/src/main/java/org/spongepowered/asm/mixin/FabricUtil.java
+++ b/src/main/java/org/spongepowered/asm/mixin/FabricUtil.java
@@ -94,10 +94,13 @@ public final class FabricUtil {
     }
 
     public static int getCompatibility(ISelectorContext context) {
-        return getCompatibility(getConfig(context));
+        return getCompatibility(context.getMixin());
     }
 
     public static int getCompatibility(IMixinContext context) {
+        if (context.isCompileTime()) {
+            return COMPATIBILITY_LATEST;
+        }
         return getCompatibility(context.getMixin().getConfig());
     }
 

--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/ElementNode.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/ElementNode.java
@@ -27,6 +27,7 @@ package org.spongepowered.asm.mixin.injection.selectors;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
@@ -166,16 +167,6 @@ public abstract class ElementNode<TNode> {
             return this.method;
         }
         
-        @Override
-        public boolean equals(Object obj) {
-            return this.method.equals(obj);
-        }
-        
-        @Override
-        public int hashCode() {
-            return this.method.hashCode();
-        }
-        
     }
     
     /**
@@ -231,16 +222,6 @@ public abstract class ElementNode<TNode> {
         public FieldNode get() {
             return this.field;
         }
-        
-        @Override
-        public boolean equals(Object obj) {
-            return this.field.equals(obj);
-        }
-        
-        @Override
-        public int hashCode() {
-            return this.field.hashCode();
-        }
 
     }
     
@@ -289,45 +270,27 @@ public abstract class ElementNode<TNode> {
         public MethodInsnNode get() {
             return this.insn;
         }
-        
-        @Override
-        public boolean equals(Object obj) {
-            return this.insn.equals(obj);
-        }
-        
-        @Override
-        public int hashCode() {
-            return this.insn.hashCode();
-        }
 
     }
     
     /**
-     * ElementNode for InvokeDynamicInsnNode
+     * ElementNode for SAM instantiations using INVOKEDYNAMIC
      */
-    static class ElementNodeInvokeDynamicInsn extends ElementNode<InvokeDynamicInsnNode> {
+    static class ElementNodeLmfInsn extends ElementNode<InvokeDynamicInsnNode> {
         
-        private InvokeDynamicInsnNode insn;
+        private final InvokeDynamicInsnNode insn;
         
-        private Type samMethodType;
+        private final Type samMethodType;
         
-        private Handle implMethod;
+        private final Handle implMethod;
         
-        private Type instantiatedMethodType;
+        private final Type instantiatedMethodType;
         
-        ElementNodeInvokeDynamicInsn(InvokeDynamicInsnNode invokeDynamic) {
+        ElementNodeLmfInsn(InvokeDynamicInsnNode invokeDynamic) {
             this.insn = invokeDynamic;
-            
-            if (invokeDynamic.bsmArgs != null && invokeDynamic.bsmArgs.length > 1) {
-                Object samMethodType = invokeDynamic.bsmArgs[0];
-                Object implMethod = invokeDynamic.bsmArgs[1];
-                Object instantiatedMethodType = invokeDynamic.bsmArgs[2];
-                if (samMethodType instanceof Type && implMethod instanceof Handle && instantiatedMethodType instanceof Type) {
-                    this.samMethodType = (Type)samMethodType;
-                    this.implMethod = (Handle)implMethod;
-                    this.instantiatedMethodType = (Type)instantiatedMethodType;
-                }
-            }
+            this.samMethodType = (Type) invokeDynamic.bsmArgs[0];
+            this.implMethod = (Handle) invokeDynamic.bsmArgs[1];
+            this.instantiatedMethodType = (Type) invokeDynamic.bsmArgs[2];
         }
         
         @Override
@@ -337,7 +300,7 @@ public abstract class ElementNode<TNode> {
         
         @Override
         public boolean isField() {
-            return this.implMethod != null && Handles.isField(this.implMethod);
+            return Handles.isField(this.implMethod);
         }
         
         @Override
@@ -347,7 +310,12 @@ public abstract class ElementNode<TNode> {
         
         @Override
         public String getOwner() {
-            return this.implMethod != null ? this.implMethod.getOwner() : this.insn.name;
+            return Type.getReturnType(this.insn.desc).getInternalName();
+        }
+
+        @Override
+        public String getImplOwner() {
+            return this.implMethod.getOwner();
         }
 
         @Override
@@ -356,23 +324,18 @@ public abstract class ElementNode<TNode> {
         }
         
         @Override
-        public String getSyntheticName() {
-            return this.implMethod != null ? this.implMethod.getName() : this.insn.name;
+        public String getImplName() {
+            return this.implMethod.getName();
         }
         
         @Override
         public String getDesc() {
-            return this.implMethod != null ? this.implMethod.getDesc() : this.insn.desc;
-        }
-        
-        @Override
-        public String getDelegateDesc() {
-            return this.samMethodType != null ? this.samMethodType.getDescriptor() : this.getDesc();
+            return this.instantiatedMethodType.getDescriptor();
         }
         
         @Override
         public String getImplDesc() {
-            return this.instantiatedMethodType != null ? this.instantiatedMethodType.getDescriptor() : this.getDesc();
+            return this.implMethod.getDesc();
         }
         
         @Override
@@ -384,17 +347,13 @@ public abstract class ElementNode<TNode> {
         public InvokeDynamicInsnNode get() {
             return this.insn;
         }
-        
-        @Override
-        public boolean equals(Object obj) {
-            return this.insn.equals(obj);
-        }
-        
-        @Override
-        public int hashCode() {
-            return this.insn.hashCode();
-        }
 
+        static ElementNodeLmfInsn of(InvokeDynamicInsnNode insn) {
+            if (!insn.bsm.equals(Handles.LMF_HANDLE) && !insn.bsm.equals(Handles.ALT_LMF_HANDLE)) {
+                return null;
+            }
+            return new ElementNodeLmfInsn(insn);
+        }
     }
     
     /**
@@ -447,16 +406,6 @@ public abstract class ElementNode<TNode> {
         public FieldInsnNode get() {
             return this.insn;
         }
-        
-        @Override
-        public boolean equals(Object obj) {
-            return this.insn.equals(obj);
-        }
-        
-        @Override
-        public int hashCode() {
-            return this.insn.hashCode();
-        }
 
     }
     
@@ -467,11 +416,11 @@ public abstract class ElementNode<TNode> {
         
         private final Iterator<AbstractInsnNode> iter;
         
-        private final boolean filterDynamic;
+        private final boolean filterLmf;
         
-        ElementNodeIterator(Iterator<AbstractInsnNode> iter, boolean filterDynamic) {
+        ElementNodeIterator(Iterator<AbstractInsnNode> iter, boolean filterLmf) {
             this.iter = iter;
-            this.filterDynamic = filterDynamic;
+            this.filterLmf = filterLmf;
         }
 
         @Override
@@ -482,7 +431,7 @@ public abstract class ElementNode<TNode> {
         @Override
         public ElementNode<AbstractInsnNode> next() {
             AbstractInsnNode elem = this.iter.next();
-            return !this.filterDynamic || (elem != null && elem.getOpcode() == Opcodes.INVOKEDYNAMIC) ? ElementNode.of(elem) : null;
+            return !this.filterLmf || (elem != null && elem.getOpcode() == Opcodes.INVOKEDYNAMIC) ? ElementNode.of(elem) : null;
         }
         
     }
@@ -494,16 +443,16 @@ public abstract class ElementNode<TNode> {
         
         private final Iterable<AbstractInsnNode> iterable;
 
-        private final boolean filterDynamic;
+        private final boolean filterLmf;
         
-        public ElementNodeIterable(Iterable<AbstractInsnNode> iterable, boolean filterDynamic) {
+        public ElementNodeIterable(Iterable<AbstractInsnNode> iterable, boolean filterLmf) {
             this.iterable = iterable;
-            this.filterDynamic = filterDynamic;
+            this.filterLmf = filterLmf;
 }
 
         @Override
         public Iterator<ElementNode<AbstractInsnNode>> iterator() {
-            return new ElementNodeIterator(this.iterable.iterator(), this.filterDynamic);
+            return new ElementNodeIterator(this.iterable.iterator(), this.filterLmf);
         }
         
     }
@@ -549,9 +498,17 @@ public abstract class ElementNode<TNode> {
     
     /**
      * Get the element owner's name, if this element has an owner, otherwise
-     * returns <tt>null</tt>
+     * returns <tt>null</tt>. For LMF elements this is the SAM type
+     * being implemented.
      */
     public abstract String getOwner();
+
+    /**
+     * For LMF elements, returns the owner of the implementing method.
+     */
+    public String getImplOwner() {
+        return this.getOwner();
+    }
     
     /**
      * Get the element name
@@ -559,30 +516,21 @@ public abstract class ElementNode<TNode> {
     public abstract String getName();
     
     /**
-     * Get the synthetic element name. For INVOKEDYNAMIC elements this is the
-     * real name of the lambda method implementing the delegate.
+     * For LMF elements, returns the real name of the implementing method.
      */
-    public String getSyntheticName() {
+    public String getImplName() {
         return this.getName();
     }
     
     /**
-     * Get the element descriptor. For INVOKEDYNAMIC this is the full descriptor
-     * of the lambda (including prepended captures).
+     * Get the element descriptor. For LMF elements this is the specialised
+     * descriptor of the SAM.
      */
     public abstract String getDesc();
     
     /**
-     * For INVOKEDYNAMIC elements, returns original descriptor of the delegate. 
-     */
-    public String getDelegateDesc() {
-        return this.getDesc();
-    }
-    
-    /**
-     * For INVOKEDYNAMIC elements, returns specialised descriptor of the
-     * delegate (lambda descriptor without prepended captures), can be the same
-     * as the delegate descriptor or more specialised. 
+     * For LMF elements, returns the full descriptor of the implementing
+     * method (including any leading parameters bound to it).
      */
     public String getImplDesc() {
         return this.getDesc();
@@ -609,6 +557,16 @@ public abstract class ElementNode<TNode> {
             owner = "L" + owner + ";";
         }
         return String.format("%s%s%s", owner, Strings.nullToEmpty(this.getName()), desc);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return this.getClass() == obj.getClass() && Objects.equals(this.get(), ((ElementNode<?>) obj).get());
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(this.get());
     }
 
     /**
@@ -654,7 +612,7 @@ public abstract class ElementNode<TNode> {
         } else if (node instanceof MethodInsnNode) {
             return (ElementNode<TNode>)new ElementNodeMethodInsn((MethodInsnNode)node);
         } else if (node instanceof InvokeDynamicInsnNode) {
-            return (ElementNode<TNode>)new ElementNodeInvokeDynamicInsn((InvokeDynamicInsnNode)node);
+            return (ElementNode<TNode>) ElementNodeLmfInsn.of((InvokeDynamicInsnNode)node);
         } else if (node instanceof FieldInsnNode) {
             return (ElementNode<TNode>)new ElementNodeFieldInsn((FieldInsnNode)node);
         }
@@ -675,7 +633,7 @@ public abstract class ElementNode<TNode> {
         if (node instanceof MethodInsnNode) {
             return (ElementNode<TNode>)new ElementNodeMethodInsn((MethodInsnNode)node);
         } else if (node instanceof InvokeDynamicInsnNode) {
-            return (ElementNode<TNode>)new ElementNodeInvokeDynamicInsn((InvokeDynamicInsnNode)node);
+            return (ElementNode<TNode>) ElementNodeLmfInsn.of((InvokeDynamicInsnNode)node);
         } else if (node instanceof FieldInsnNode) {
             return (ElementNode<TNode>)new ElementNodeFieldInsn((FieldInsnNode)node);
         }
@@ -742,12 +700,12 @@ public abstract class ElementNode<TNode> {
     
     /**
      * Get a wrapped version of the supplied insn list which returns element
-     * nodes for every INVOKEDYNAMIC instruction only
+     * nodes for every LMF instruction only
      * 
      * @param insns Insn list to wrap
      * @return Wrapper for insn list
      */
-    public static Iterable<ElementNode<AbstractInsnNode>> dynamicInsnList(InsnList insns) {
+    public static Iterable<ElementNode<AbstractInsnNode>> lmfInsnList(InsnList insns) {
         return new ElementNodeIterable(insns, true);
     }
     

--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/ITargetSelector.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/ITargetSelector.java
@@ -113,6 +113,12 @@ public interface ITargetSelector {
          * to set defaults for match limits based on role. 
          */
         SELECT_MEMBER(0),
+
+        /**
+         * Configure this selector for matching lambdas in a method. Usually used
+         * to set defaults for match limits based on role.
+         */
+        SELECT_LAMBDA(0),
         
         /**
          * Configure this selector for matching field and method instructions in
@@ -172,6 +178,22 @@ public interface ITargetSelector {
      * <p>Can return null</p>
      */
     public abstract ITargetSelector next();
+
+    /**
+     * Minimum relative nesting level at which to search for the {@link next}
+     * selector.
+     */
+    public default int getMinRecurseDepth() {
+        return 1;
+    }
+
+    /**
+     * Maximum relative nesting level at which to search for the {@link next}
+     * selector.
+     */
+    public default int getMaxRecurseDepth() {
+        return 1;
+    }
     
     /**
      * Configure and return a modified version of this selector by consuming the
@@ -204,6 +226,18 @@ public interface ITargetSelector {
      * @throws InvalidSelectorException if any sanity check fails
      */
     public abstract ITargetSelector validate() throws InvalidSelectorException;
+
+    /**
+     * Validates the {@link next} selector recursively.
+     *
+     * @throws InvalidSelectorException if any checks fail
+     */
+    public default void validateNext() throws InvalidSelectorException {
+        ITargetSelector next = this.next();
+        if (next != null) {
+            next.validate().validateNext();
+        }
+    }
 
     /**
      * Attach this selector to the specified context. Should return this

--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/MemberMatcher.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/MemberMatcher.java
@@ -179,7 +179,7 @@ public final class MemberMatcher implements ITargetSelector {
      */
     @Override
     public ITargetSelector next() {
-        return this; // Regex matcher flows into targets
+        return null;
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelectors.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/TargetSelectors.java
@@ -24,23 +24,19 @@
  */
 package org.spongepowered.asm.mixin.injection.selectors;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
+import org.spongepowered.asm.logging.ILogger;
+import org.spongepowered.asm.mixin.FabricUtil;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.MixinEnvironment.Option;
 import org.spongepowered.asm.mixin.injection.selectors.ITargetSelector.Configure;
-import org.spongepowered.asm.mixin.injection.selectors.TargetSelector.Result;
 import org.spongepowered.asm.mixin.injection.selectors.throwables.SelectorConstraintException;
 import org.spongepowered.asm.mixin.injection.struct.InvalidMemberDescriptorException;
 import org.spongepowered.asm.mixin.injection.struct.TargetNotSupportedException;
@@ -48,54 +44,34 @@ import org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionExceptio
 import org.spongepowered.asm.mixin.refmap.IMixinContext;
 import org.spongepowered.asm.mixin.struct.AnnotatedMethodInfo;
 import org.spongepowered.asm.mixin.transformer.meta.MixinMerged;
+import org.spongepowered.asm.service.MixinService;
 import org.spongepowered.asm.util.Annotations;
 import org.spongepowered.asm.util.Bytecode;
+import org.spongepowered.asm.util.NameAndDesc;
+
+import com.google.common.collect.Lists;
 
 public class TargetSelectors implements Iterable<TargetSelectors.SelectedMethod> {
+
+    private static final ILogger logger = MixinService.getService().getLogger("mixin");
     
     /**
-     * Selected target method, paired with the selector which identified it
+     * Selected target method
      */
     public static class SelectedMethod {
-        
-        /**
-         * The parent target of this target. If this target is a lambda then
-         * this will be the selector for the enclosing method. Parent is null
-         * for the outermost method.
-         */
-        private final SelectedMethod parent;
-        
-        /**
-         * The target selector which selected this target
-         */
-        private final ITargetSelector selector;
-        
+
         /**
          * The selected target method
          */
         private final MethodNode method;
 
-        SelectedMethod(SelectedMethod parent, ITargetSelector selector, MethodNode method) {
-            this.parent = parent;
-            this.selector = selector;
+        SelectedMethod(MethodNode method) {
             this.method = method;
-        }
-        
-        SelectedMethod(ITargetSelector selector, MethodNode method) {
-            this(null, selector, method);
         }
         
         @Override
         public String toString() {
             return this.method.name + this.method.desc;
-        }
-        
-        public SelectedMethod getParent() {
-            return this.parent;
-        }
-        
-        public ITargetSelector next() {
-            return this.selector.next();
         }
 
         public MethodNode getMethod() {
@@ -130,7 +106,27 @@ public class TargetSelectors implements Iterable<TargetSelectors.SelectedMethod>
      * Whether the annotated method is static
      */
     private final boolean isStatic;
-    
+
+    /**
+     * An index of methods within the target class
+     */
+    private final Map<NameAndDesc, MethodNode> methodIndex;
+
+    /**
+     * Whether we have already scraped lambda information
+     */
+    private boolean scrapedLambdas = false;
+
+    /**
+     * An index of the lambdas contained within each method, populated lazily
+     */
+    private final Map<MethodNode, List<ElementNode<?>>> containedLambdas = new IdentityHashMap<>();
+
+    /**
+     * All the methods which are lambdas, populated lazily
+     */
+    private final Set<MethodNode> lambdaMethods = Collections.newSetFromMap(new IdentityHashMap<>());
+
     /**
      * Root selectors
      */
@@ -147,13 +143,16 @@ public class TargetSelectors implements Iterable<TargetSelectors.SelectedMethod>
         this.mixin = context.getMixin();
         this.method = context.getMethod();       
         this.isStatic = this.method instanceof MethodNode && Bytecode.isStatic((MethodNode)this.method);
+        this.methodIndex = classNode.methods.stream()
+                .collect(Collectors.toMap(NameAndDesc::new, Function.identity(), (a, b) -> a));
     }
 
     public void parse(Set<ITargetSelector> selectors) {
         // Validate and attach the parsed selectors
         for (ITargetSelector selector : selectors) {
             try {
-                this.addSelector(selector.validate().attach(this.context));
+                this.validateSelector(selector);
+                this.addSelector(selector.attach(this.context));
             } catch (InvalidMemberDescriptorException ex) {
                 throw new InvalidInjectionException(this.context, String.format("%s, has invalid target descriptor: %s. %s",
                         this.context.getElementDescription(), ex.getMessage(), this.mixin.getReferenceMapper().getStatus()));
@@ -164,6 +163,13 @@ public class TargetSelectors implements Iterable<TargetSelectors.SelectedMethod>
                 throw new InvalidInjectionException(this.context, String.format("%s is decorated with an invalid selector: %s",
                         this.context.getElementDescription(), ex.getMessage()));
             }
+        }
+    }
+
+    private void validateSelector(ITargetSelector selector) {
+        selector.validate();
+        if (FabricUtil.getCompatibility(this.context) >= FabricUtil.COMPATIBILITY_0_17_5) {
+            selector.validateNext();
         }
     }
 
@@ -193,87 +199,141 @@ public class TargetSelectors implements Iterable<TargetSelectors.SelectedMethod>
      * Find methods in the target class which match the parsed selectors
      */
     public void find() {
-        this.findRootTargets();
-        // this.findNestedTargets();
-    }
+        LinkedHashSet<MethodNode> selected = new LinkedHashSet<>();
 
-    /**
-     * Evaluate the root selectors parsed from this injector, find the root
-     * targets and store them in the {@link #targets} collection.
-     */
-    private void findRootTargets() {
         for (ITargetSelector selector : this.selectors) {
-            selector = selector.configure(Configure.SELECT_MEMBER);
-            
-            int matchCount = 0;
-            int maxCount = selector.getMaxMatchCount();
-
-            for (MethodNode target : this.targetClassNode.methods) {
-                if (selector.match(ElementNode.of(this.targetClassNode, target)).isExactMatch()) {
-                    matchCount++;
-
-                    boolean isMixinMethod = Annotations.getVisible(target, MixinMerged.class) != null;
-                    if (maxCount <= 1 || ((this.isStatic || !Bytecode.isStatic(target)) && target != this.method && !isMixinMethod)) {
-                        this.checkTarget(target);
-                        this.targets.add(new SelectedMethod(selector, target));
-                    }
-
-                    if (matchCount >= maxCount) {
-                        break;
-                    }
+            List<MethodNode> roots = this.findRootTargets(selector);
+            if (roots.isEmpty()) {
+                continue;
+            }
+            if (selector.next() == null || FabricUtil.getCompatibility(this.context) < FabricUtil.COMPATIBILITY_0_17_5) {
+                // Must ignore nested selectors to match prior behaviour
+                if (selector.next() != null) {
+                    String advice = MixinService.getService().getAdviceProvider().higherCompatibilityNeeded(
+                            FabricUtil.COMPATIBILITY_0_17_5,
+                            "0.17.5"
+                    );
+                    TargetSelectors.logger.warn(
+                            "{} specifies a nested target selector which is being ignored at the current "
+                                    + "compatibility version. Advice for the author: {}",
+                            this.context, advice
+                    );
                 }
+                selected.addAll(roots);
+                continue;
+            }
+            this.scrapeLambdas();
+
+            LinkedHashSet<ElementNode<?>> working = roots.stream()
+                    .filter(root -> !this.lambdaMethods.contains(root))
+                    .map(root -> ElementNode.of(this.targetClassNode, root))
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+
+            while (selector.next() != null) {
+                int minDepth = selector.getMinRecurseDepth();
+                int maxDepth = selector.getMaxRecurseDepth();
+                selector = selector.next().configure(Configure.SELECT_LAMBDA);
+
+                LinkedHashSet<ElementNode<?>> children = this.findNested(selector, working, minDepth, maxDepth);
+                this.checkMinMatches(selector, children.size());
+                working = children;
             }
 
-            if (matchCount < selector.getMinMatchCount()) {
-                throw new InvalidInjectionException(this.context, new SelectorConstraintException(selector, String.format(
-                        "Injection validation failed: %s for %s did not match the required number of targets (required=%d, matched=%d). %s%s",
-                        selector, this.context.getElementDescription(), selector.getMinMatchCount(), matchCount,
-                        this.mixin.getReferenceMapper().getStatus(), AnnotatedMethodInfo.getDynamicInfo(this.method))));
+            for (ElementNode<?> node : working) {
+                selected.add(this.findMethod(node));
             }
         }
+
+        this.submitTargets(selected);
     }
 
     /**
-     * For each root target, resolve the nested targets from the target
-     * descriptor
+     * Recursively finds nested matches for the given selector in the given root
+     * methods, depth-first.
+     *
+     * @param selector selector to be matched against the nested elements
+     * @param parents root methods in which to search for lambdas
+     * @param minDepth minimum relative nesting level to be matched
+     * @param maxDepth maximum relative nesting level to be matched
+     * @return matched elements
      */
-    protected void findNestedTargets() {
-        boolean recursed = false;
-        do {
-            recursed = false;
-            for (ListIterator<SelectedMethod> iter = this.targets.listIterator(); iter.hasNext();) {
-                SelectedMethod target = iter.next();
-                ITargetSelector next = target.next();
-                if (next == null) {
+    private LinkedHashSet<ElementNode<?>> findNested(
+            ITargetSelector selector, Collection<ElementNode<?>> parents, int minDepth, int maxDepth
+    ) {
+        LinkedHashSet<ElementNode<?>> children = new LinkedHashSet<>();
+        if (selector.getMaxMatchCount() <= 0) {
+            return children;
+        }
+
+        for (ElementNode<?> parent : parents) {
+            List<WithDepth<ElementNode<?>>> stack = new ArrayList<>();
+            stack.add(new WithDepth<>(parent, 0));
+
+            while (!stack.isEmpty()) {
+                WithDepth<ElementNode<?>> current = stack.remove(stack.size() - 1);
+
+                if (current.depth >= minDepth && selector.match(current.value).isExactMatch()) {
+                    children.add(current.value);
+                    if (children.size() == selector.getMaxMatchCount()) {
+                        return children;
+                    }
+                }
+
+                if (current.depth >= maxDepth) {
+                    // Stop looking
                     continue;
                 }
-                
-                recursed = true;
-                Result<AbstractInsnNode> result = TargetSelector.run(next, ElementNode.dynamicInsnList(target.getMethod().instructions));
-                iter.remove();
-                for (ElementNode<AbstractInsnNode> candidate : result.candidates) {
-                    if (candidate.getInsn().getOpcode() != Opcodes.INVOKEDYNAMIC) {
-                        continue;
-                    }
-                    
-                    if (!candidate.getOwner().equals(this.mixin.getTargetClassRef())) {
-                        throw new InvalidInjectionException(this.context, String.format(
-                                "%s, failed to select into child. Cannot select foreign method: %s. %s",
-                                this.context.getElementDescription(), candidate, this.mixin.getReferenceMapper().getStatus()));
-                    }
-                    
-                    MethodNode method = this.findMethod(candidate);
-                    if (method == null) {
-                        throw new InvalidInjectionException(this.context, String.format(
-                                "%s, failed to select into child. %s%s was not found in the target class.",
-                                this.context.getElementDescription(), candidate.getName(), candidate.getDesc()));
-                    }
 
-                    iter.add(new SelectedMethod(target, next, method));
+                for (ElementNode<?> lambda : Lists.reverse(this.containedLambdas.get(this.findMethod(current.value)))) {
+                    stack.add(new WithDepth<>(lambda, current.depth + 1));
                 }
             }
         }
-        while (recursed);
+        return children;
+    }
+
+    /**
+     * Finds the root matches for the given selector in the target class
+     * (ignores nested selectors).
+     */
+    private List<MethodNode> findRootTargets(ITargetSelector selector) {
+        selector = selector.configure(Configure.SELECT_MEMBER);
+
+        List<MethodNode> result = new ArrayList<>();
+        int maxCount = selector.getMaxMatchCount();
+
+        for (MethodNode target : this.targetClassNode.methods) {
+            if (selector.match(ElementNode.of(this.targetClassNode, target)).isExactMatch()) {
+                boolean isMixinMethod = Annotations.getVisible(target, MixinMerged.class) != null;
+                if (maxCount <= 1 || ((this.isStatic || !Bytecode.isStatic(target)) && target != this.method && !isMixinMethod)) {
+                    result.add(target);
+                }
+
+                if (result.size() >= maxCount) {
+                    break;
+                }
+            }
+        }
+
+        this.checkMinMatches(selector, result.size());
+
+        return result;
+    }
+
+    private void checkMinMatches(ITargetSelector selector, int matchCount) {
+        if (matchCount < selector.getMinMatchCount()) {
+            throw new InvalidInjectionException(this.context, new SelectorConstraintException(selector, String.format(
+                    "Injection validation failed: %s for %s did not match the required number of targets (required=%d, matched=%d). %s%s",
+                    selector, this.context.getElementDescription(), selector.getMinMatchCount(), matchCount,
+                    this.mixin.getReferenceMapper().getStatus(), AnnotatedMethodInfo.getDynamicInfo(this.method))));
+        }
+    }
+
+    private void submitTargets(Iterable<MethodNode> targets) {
+        for (MethodNode target : targets) {
+            this.checkTarget(target);
+            this.targets.add(new SelectedMethod(target));
+        }
     }
 
     private void checkTarget(MethodNode target) {
@@ -289,17 +349,54 @@ public class TargetSelectors implements Iterable<TargetSelectors.SelectedMethod>
     }
 
     /**
-     * Finds a method in the target class
-     * 
-     * @return Target method matching searchFor, or null if not found
+     * If not done already, scrapes lambda information from all methods in the
+     * target class, populating {@link containedLambdas} and
+     * {@link lambdaMethods}.
      */
-    private MethodNode findMethod(ElementNode<AbstractInsnNode> searchFor) {
-        for (MethodNode target : this.targetClassNode.methods) {
-            if (target.name.equals(searchFor.getSyntheticName()) && target.desc.equals(searchFor.getDesc())) {
-                return target;
+    private void scrapeLambdas() {
+        if (this.scrapedLambdas) {
+            return;
+        }
+        this.scrapedLambdas = true;
+
+        for (MethodNode parent : this.targetClassNode.methods) {
+            List<ElementNode<?>> lambdas = this.findContainedLambdas(parent);
+            this.containedLambdas.put(parent, lambdas);
+            for (ElementNode<?> lambda : lambdas) {
+                this.lambdaMethods.add(this.findMethod(lambda));
             }
         }
-        return null;
+    }
+
+    private List<ElementNode<?>> findContainedLambdas(MethodNode parent) {
+        List<ElementNode<?>> result = new ArrayList<>();
+        for (ElementNode<?> candidate : ElementNode.lmfInsnList(parent.instructions)) {
+            if (candidate == null) {
+                continue;
+            }
+            if (!candidate.getImplOwner().equals(this.mixin.getTargetClassRef())) {
+                // Reference to a foreign method
+                continue;
+            }
+
+            MethodNode method = this.findMethod(candidate);
+
+            if (Bytecode.hasFlag(method, Opcodes.ACC_SYNTHETIC) && !Bytecode.hasFlag(method, Opcodes.ACC_BRIDGE)) {
+                result.add(candidate);
+            }
+        }
+        return result;
+    }
+
+    private MethodNode findMethod(ElementNode<?> node) {
+        NameAndDesc candidate = new NameAndDesc(node.getImplName(), node.getImplDesc());
+        MethodNode method = this.methodIndex.get(candidate);
+        if (method == null) {
+            throw new InvalidInjectionException(this.context, String.format(
+                    "%s failed to find %s in target class %s",
+                    this.context.getElementDescription(), candidate, this.mixin.getTargetClassRef()));
+        }
+        return method;
     }
 
     /**
@@ -350,6 +447,19 @@ public class TargetSelectors implements Iterable<TargetSelectors.SelectedMethod>
             index++;
         }
         return sb.toString();
+    }
+
+    /**
+     * DFS helper.
+     */
+    private static final class WithDepth<T> {
+        public final T value;
+        public final int depth;
+
+        public WithDepth(T value, int depth) {
+            this.value = value;
+            this.depth = depth;
+        }
     }
 
 }

--- a/src/main/java/org/spongepowered/asm/mixin/injection/selectors/dynamic/DynamicSelectorDesc.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/selectors/dynamic/DynamicSelectorDesc.java
@@ -456,6 +456,7 @@ public class DynamicSelectorDesc implements ITargetSelectorDynamic, ITargetSelec
                     return new DynamicSelectorDesc(this, Quantifier.SINGLE);
                 }
                 break;
+            case SELECT_LAMBDA:
             case SELECT_INSTRUCTION:
                 if (this.matches.isDefault()) {
                     return new DynamicSelectorDesc(this, Quantifier.ANY);

--- a/src/main/java/org/spongepowered/asm/mixin/injection/struct/MemberInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/struct/MemberInfo.java
@@ -28,14 +28,8 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
-import org.spongepowered.asm.mixin.injection.selectors.ElementNode;
-import org.spongepowered.asm.mixin.injection.selectors.ISelectorContext;
-import org.spongepowered.asm.mixin.injection.selectors.ITargetSelector;
-import org.spongepowered.asm.mixin.injection.selectors.ITargetSelectorByName;
-import org.spongepowered.asm.mixin.injection.selectors.ITargetSelectorConstructor;
-import org.spongepowered.asm.mixin.injection.selectors.ITargetSelectorRemappable;
-import org.spongepowered.asm.mixin.injection.selectors.InvalidSelectorException;
-import org.spongepowered.asm.mixin.injection.selectors.MatchResult;
+import org.spongepowered.asm.mixin.FabricUtil;
+import org.spongepowered.asm.mixin.injection.selectors.*;
 import org.spongepowered.asm.mixin.throwables.MixinException;
 import org.spongepowered.asm.obfuscation.mapping.IMapping;
 import org.spongepowered.asm.obfuscation.mapping.common.MappingField;
@@ -869,39 +863,44 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
      * @return parsed MemberInfo
      */
     public static MemberInfo parse(final String input, final ISelectorContext context) {
+        boolean isModern = context == null || FabricUtil.getCompatibility(context) >= FabricUtil.COMPATIBILITY_0_17_5;
+
         String desc = null;
         String owner = null;
-        String name = Strings.nullToEmpty(input).replaceAll("\\s", "");
-        String tail = null;
-        
-        int arrowPos = name.indexOf(MemberInfo.ARROW);
-        if (arrowPos > -1) {
-            tail = name.substring(arrowPos + 2);
-            name = name.substring(0, arrowPos);
+        String name = Strings.nullToEmpty(input);
+
+        if (!isModern) {
+            name = name.replaceAll("\\s", "");
+
+            int arrowPos = name.indexOf(MemberInfo.ARROW);
+            if (arrowPos > -1) {
+                name = name.substring(0, arrowPos);
+            }
         }
 
         if (context != null) {
             name = context.remap(name);
         }
+        name = name.trim();
 
         int parenPos = name.indexOf('(');
         int colonPos = name.indexOf(':');
         if (parenPos > -1) {
-            desc = name.substring(parenPos);
-            name = name.substring(0, parenPos);
+            desc = name.substring(parenPos).trim();
+            name = name.substring(0, parenPos).trim();
         } else if (colonPos > -1) {
-            desc = name.substring(colonPos + 1);
-            name = name.substring(0, colonPos);
+            desc = name.substring(colonPos + 1).trim();
+            name = name.substring(0, colonPos).trim();
         }
         
         int lastDotPos = name.lastIndexOf('.');
         int semiColonPos = name.indexOf(';');
         if (lastDotPos > -1) {
-            owner = name.substring(0, lastDotPos).replace('.', '/');
-            name = name.substring(lastDotPos + 1);
+            owner = name.substring(0, lastDotPos).replace('.', '/').trim();
+            name = name.substring(lastDotPos + 1).trim();
         } else if (semiColonPos > -1 && name.startsWith("L")) {
-            owner = name.substring(1, semiColonPos).replace('.', '/');
-            name = name.substring(semiColonPos + 1);
+            owner = name.substring(1, semiColonPos).replace('.', '/').trim();
+            name = name.substring(semiColonPos + 1).trim();
         }
         
         if ((name.indexOf('/') > -1 || name.indexOf('.') > -1) && owner == null) {
@@ -919,22 +918,22 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
         Quantifier quantifier = Quantifier.DEFAULT;
         if (name.endsWith("*")) {
             quantifier = Quantifier.ANY;
-            name = name.substring(0, name.length() - 1);
+            name = name.substring(0, name.length() - 1).trim();
         } else if (name.endsWith("+")) {
             quantifier = Quantifier.PLUS;
-            name = name.substring(0, name.length() - 1);
+            name = name.substring(0, name.length() - 1).trim();
         } else if (name.endsWith("}")) {
             quantifier = Quantifier.NONE; // Assume invalid until quantifier is parsed
             int bracePos = name.indexOf("{");
             if (bracePos >= 0) {
                 try {
                     quantifier = Quantifier.parse(name.substring(bracePos, name.length()));
-                    name = name.substring(0, bracePos);
+                    name = name.substring(0, bracePos).trim();
                 } catch (Exception ex) {
                     // Handled later in validate since matchCount will be 0
                 }
             }
-        } else if (name.indexOf("{") >= 0) {
+        } else if (name.contains("{")) {
             quantifier = Quantifier.NONE; // Probably incomplete quantifier
         }
         
@@ -942,7 +941,7 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
             name = null;
         }
         
-        return new MemberInfo(name, owner, desc, quantifier, tail, input);
+        return new MemberInfo(name, owner, desc, quantifier, null, input);
     }
 
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/injection/struct/MemberInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/struct/MemberInfo.java
@@ -24,6 +24,9 @@
  */
 package org.spongepowered.asm.mixin.injection.struct;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.FieldInsnNode;
@@ -210,7 +213,19 @@ import com.google.common.base.Strings;
  * </ul>
  */
 public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelectorConstructor {
-    
+
+    /**
+     * Shallow parsing pattern to extract nesting
+     */
+    private static final Pattern PARSER = Pattern.compile(
+            "(?<root>.*?\\S)\\s+->(?<nextDepth>\\{.*?}|\\S*)\\s+(?<next>\\S.*)"
+    );
+
+    /**
+     * Default nesting level quantifier
+     */
+    private static final Quantifier DEFAULT_DEPTH = new Quantifier(1, 1);
+
     /**
      * Separator for elements in the path
      */
@@ -245,11 +260,18 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
      * The actual String value passed into the {@link #parse} method 
      */
     private final String input;
-    
+
     /**
-     * The actual String value passed into the {@link #parse} method 
+     * The nested selector, or {@code null} if this is the last selector in the
+     * chain.
      */
-    private final String tail;
+    private final MemberInfo next;
+
+    /**
+     * The range of relative nesting levels at which to search for the
+     * {@link next} selector.
+     */
+    private Quantifier nextDepth = MemberInfo.DEFAULT_DEPTH;
     
     /**
      * ctor
@@ -258,7 +280,7 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
      * @param matches Quantifier specifying the number of matches required
      */
     public MemberInfo(String name, Quantifier matches) {
-        this(name, null, null, matches, null, null);
+        this(name, null, matches);
     }
     
     /**
@@ -270,7 +292,7 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
      * @param matches Quantifier specifying the number of matches required
      */
     public MemberInfo(String name, String owner, Quantifier matches) {
-        this(name, owner, null, matches, null, null);
+        this(name, owner, null, matches);
     }
     
     /**
@@ -282,7 +304,7 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
      * @param desc Member descriptor, can be null
      */
     public MemberInfo(String name, String owner, String desc) {
-        this(name, owner, desc, Quantifier.DEFAULT, null, null);
+        this(name, owner, desc, Quantifier.DEFAULT);
     }
     
     /**
@@ -295,43 +317,7 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
      * @param matches Quantifier specifying the number of matches required
      */
     public MemberInfo(String name, String owner, String desc, Quantifier matches) {
-        this(name, owner, desc, matches, null, null);
-    }
-    
-    /**
-     * ctor
-     * 
-     * @param name Member name, must not be null
-     * @param owner Member owner, can be null otherwise must be in internal form
-     *      without L;
-     * @param desc Member descriptor, can be null
-     * @param matches Quantifier specifying the number of matches required
-     */
-    public MemberInfo(String name, String owner, String desc, Quantifier matches, String tail) {
-        this(name, owner, desc, matches, tail, null);
-    }
-    
-    /**
-     * ctor
-     * 
-     * @param name Member name, must not be null
-     * @param owner Member owner, can be null otherwise must be in internal form
-     *      without L;
-     * @param desc Member descriptor, can be null
-     * @param matches Quantifier specifying the number of matches required
-     */
-    public MemberInfo(String name, String owner, String desc, Quantifier matches, String tail, String input) {
-        if (owner != null && owner.contains(".")) {
-            throw new IllegalArgumentException("Attempt to instance a MemberInfo with an invalid owner format");
-        }
-        
-        this.owner = owner;
-        this.name = name;
-        this.desc = desc;
-        this.matches = matches;
-        this.forceField = false;
-        this.tail = tail;
-        this.input = input;
+        this(name, owner, desc, matches, null, MemberInfo.DEFAULT_DEPTH, null);
     }
     
     /**
@@ -344,7 +330,7 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
         this.matches = Quantifier.DEFAULT;
         this.forceField = false;
         this.input = null;
-        this.tail = null;
+        this.next = null;
         
         if (insn instanceof MethodInsnNode) {
             MethodInsnNode methodNode = (MethodInsnNode) insn;
@@ -372,8 +358,8 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
         this.desc = mapping.getDesc();
         this.matches = Quantifier.SINGLE;
         this.forceField = mapping.getType() == IMapping.Type.FIELD;
-        this.tail = null;
         this.input = null;
+        this.next = null;
     }
     
     /**
@@ -387,8 +373,9 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
         this.desc = method.getDesc();
         this.matches = remapped.matches;
         this.forceField = false;
-        this.tail = null;
         this.input = null;
+        this.next = remapped.next;
+        this.nextDepth = remapped.nextDepth;
     }
 
     /**
@@ -403,15 +390,41 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
         this.desc = original.desc;
         this.matches = original.matches;
         this.forceField = original.forceField;
-        this.tail = original.tail;
         this.input = null;
+        this.next = original.next;
+        this.nextDepth = original.nextDepth;
     }
-    
+
+    private MemberInfo(String name, String owner, String desc, Quantifier matches, MemberInfo next, Quantifier nextDepth, String input) {
+        this.owner = owner;
+        this.name = name;
+        this.desc = desc;
+        this.matches = matches;
+        this.forceField = false;
+        this.input = input;
+        this.next = next;
+        this.nextDepth = nextDepth;
+    }
+
+    private MemberInfo(MemberInfo original, Quantifier newMatches) {
+        this(original.name, original.owner, original.desc, newMatches, original.next, original.nextDepth, null);
+    }
+
     @Override
     public ITargetSelector next() {
-        return Strings.isNullOrEmpty(this.tail) ? null : MemberInfo.parse(this.tail, null);
+        return this.next;
     }
-    
+
+    @Override
+    public int getMinRecurseDepth() {
+        return this.nextDepth.getClampedMin();
+    }
+
+    @Override
+    public int getMaxRecurseDepth() {
+        return this.nextDepth.getClampedMax();
+    }
+
     @Override
     public String getOwner() {
         return this.owner;
@@ -442,13 +455,33 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
      */
     @Override
     public String toString() {
+        String tail = "";
+        if (this.next != null) {
+            tail = ' ' + MemberInfo.ARROW + this.recurseDepthToString() + ' ' + this.next;
+        }
+        return this.headToString() + tail;
+    }
+
+    /**
+     * Renders the root selector as a string, ignoring nested selectors.
+     */
+    public String headToString() {
         String owner = this.owner != null ? "L" + this.owner + ";" : "";
         String name = this.name != null ? this.name : "";
         String quantifier = this.matches.toString();
         String desc = this.desc != null ? this.desc : "";
         String separator = desc.startsWith("(") ? "" : (this.desc != null ? ":" : "");
-        String tail = this.tail != null ? " " + MemberInfo.ARROW + " " + this.tail : ""; 
-        return owner + name + quantifier + separator + desc + tail;
+        return owner + name + quantifier + separator + desc;
+    }
+
+    /**
+     * Renders the nesting level quantifier as a canonical string.
+     */
+    public String recurseDepthToString() {
+        if (this.getMinRecurseDepth() == 1 && this.getMaxRecurseDepth() == 1) {
+            return "";
+        }
+        return this.nextDepth.toString();
     }
 
     /**
@@ -627,8 +660,7 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
      */
     @Override
     public MemberInfo validate() throws InvalidSelectorException {
-        // Parse emits a match count of 0 if the quantifier is incorrectly specified
-        if (this.getMaxMatchCount() == 0) {
+        if (this.matches.isInvalid() || this.matches.getClampedMax() == 0 || this.nextDepth.isInvalid()) {
             throw new InvalidMemberDescriptorException(this.input, "Malformed quantifier in selector: " + this.input);
         }
         
@@ -778,12 +810,13 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
         switch (request) {
             case SELECT_MEMBER:
                 if (this.matches.isDefault()) {
-                    return new MemberInfo(this.name, this.owner, this.desc, Quantifier.SINGLE, this.tail);
+                    return new MemberInfo(this, Quantifier.SINGLE);
                 }
                 break;
+            case SELECT_LAMBDA:
             case SELECT_INSTRUCTION:
                 if (this.matches.isDefault()) {
-                    return new MemberInfo(this.name, this.owner, this.desc, Quantifier.ANY, this.tail);
+                    return new MemberInfo(this, Quantifier.ANY);
                 }
                 break;
             case MOVE:
@@ -796,7 +829,7 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
                 return this.transform(null);
             case CLEAR_LIMITS:
                 if (this.matches.getMin() != 0 || this.matches.getMax() < Integer.MAX_VALUE) {
-                    return new MemberInfo(this.name, this.owner, this.desc, Quantifier.ANY, this.tail);
+                    return new MemberInfo(this, Quantifier.ANY);
                 }
                 break;
             default:
@@ -868,20 +901,34 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
         String desc = null;
         String owner = null;
         String name = Strings.nullToEmpty(input);
+        MemberInfo next = null;
+        Quantifier nextDepth = MemberInfo.DEFAULT_DEPTH;
 
-        if (!isModern) {
+        if (isModern) {
+            name = name.trim();
+
+            Matcher nestedMatcher = MemberInfo.PARSER.matcher(name);
+            if (nestedMatcher.matches()) {
+                name = nestedMatcher.group("root").trim();
+                Quantifier parsedDepth = Quantifier.parse(nestedMatcher.group("nextDepth"));
+                if (!parsedDepth.isDefault()) {
+                    nextDepth = parsedDepth;
+                }
+                next = MemberInfo.parse(nestedMatcher.group("next"), null);
+            }
+        } else {
             name = name.replaceAll("\\s", "");
 
             int arrowPos = name.indexOf(MemberInfo.ARROW);
             if (arrowPos > -1) {
+                next = MemberInfo.parse(name.substring(arrowPos + 2), context);
                 name = name.substring(0, arrowPos);
             }
         }
 
         if (context != null) {
-            name = context.remap(name);
+            name = context.remap(name).trim();
         }
-        name = name.trim();
 
         int parenPos = name.indexOf('(');
         int colonPos = name.indexOf(':');
@@ -941,7 +988,7 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
             name = null;
         }
         
-        return new MemberInfo(name, owner, desc, quantifier, null, input);
+        return new MemberInfo(name, owner, desc, quantifier, next, nextDepth, input);
     }
 
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/injection/struct/MemberInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/struct/MemberInfo.java
@@ -763,43 +763,6 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
         }
         return MatchResult.EXACT_MATCH;
     }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof ITargetSelectorByName)) {
-            return false;
-        }
-        
-        ITargetSelectorByName other = (ITargetSelectorByName)obj;
-        boolean otherForceField = other instanceof MemberInfo ? ((MemberInfo)other).forceField
-                : other instanceof ITargetSelectorRemappable ? ((ITargetSelectorRemappable)other).isField() : false;
-        
-        return this.compareMatches(other) && this.forceField == otherForceField
-                && Objects.equal(this.owner, other.getOwner())
-                && Objects.equal(this.name, other.getName())
-                && Objects.equal(this.desc, other.getDesc());
-    }
-    
-    /**
-     * Compare local match count with match count of other selector
-     */
-    private boolean compareMatches(ITargetSelectorByName other) {
-        if (other instanceof MemberInfo) {
-            return ((MemberInfo)other).matches.equals(this.matches);
-        }
-        return this.getMinMatchCount() == other.getMinMatchCount() && this.getMaxMatchCount() == other.getMaxMatchCount();
-    }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(this.matches, this.owner, this.name, this.desc);
-    }
     
     /* (non-Javadoc)
      * @see org.spongepowered.asm.mixin.injection.selectors.ITargetSelector

--- a/src/main/java/org/spongepowered/asm/mixin/injection/struct/MemberInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/injection/struct/MemberInfo.java
@@ -32,6 +32,7 @@ import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.spongepowered.asm.mixin.FabricUtil;
+import org.spongepowered.asm.mixin.extensibility.IRemapper;
 import org.spongepowered.asm.mixin.injection.selectors.*;
 import org.spongepowered.asm.mixin.throwables.MixinException;
 import org.spongepowered.asm.obfuscation.mapping.IMapping;
@@ -331,7 +332,7 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
         this.forceField = false;
         this.input = null;
         this.next = null;
-        
+
         if (insn instanceof MethodInsnNode) {
             MethodInsnNode methodNode = (MethodInsnNode) insn;
             this.owner = methodNode.owner;
@@ -887,7 +888,95 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
     public ITargetSelectorRemappable remapUsing(MappingMethod srgMethod, boolean setOwner) {
         return new MemberInfo(this, srgMethod, setOwner);
     }
-    
+
+    /**
+     * Remaps this selector using the given remapper, assuming that this is a
+     * <b>top-level</b> selector.
+     * @param remapper the remapper to use
+     * @return the remapped selector, or {@code null} if no change.
+     */
+    public MemberInfo remapUsing(IRemapper remapper) {
+        boolean changed = false;
+
+        String name = this.name;
+        if (name != null) {
+            if (this.isField()) {
+                name = remapper.mapFieldName(this.owner, name, this.desc);
+            } else {
+                name = remapper.mapMethodName(this.owner, name, this.desc);
+            }
+            changed = changed || !this.name.equals(name);
+        }
+
+        String owner = this.owner;
+        if (owner != null) {
+            owner = remapper.map(owner);
+            changed = changed || !this.owner.equals(owner);
+        }
+
+        String desc = this.desc;
+        if (desc != null) {
+            desc = remapper.mapDesc(desc);
+            changed = changed || !this.desc.equals(desc);
+        }
+
+        MemberInfo next = this.next;
+        if (next != null) {
+            MemberInfo remappedNext = next.remapNestedUsing(remapper);
+            if (remappedNext != null) {
+                changed = true;
+                next = remappedNext;
+            }
+        }
+
+        if (!changed) {
+            return null;
+        }
+
+        return new MemberInfo(name, owner, desc, this.matches, next, this.nextDepth, null);
+    }
+
+    /**
+     * Remaps this selector using the given remapper, assuming that this is a
+     * <b>nested</b> selector.
+     * @param remapper the remapper to use
+     * @return the remapped selector, or {@code null} if no change.
+     */
+    public MemberInfo remapNestedUsing(IRemapper remapper) {
+        boolean changed = false;
+
+        String desc = this.desc;
+        if (desc != null) {
+            desc = remapper.mapDesc(desc);
+            changed = changed || !this.desc.equals(desc);
+        }
+
+        String owner = this.owner;
+        String name = null;
+        if (owner != null) {
+            // The owner is enough to uniquely identify the SAM, strip the name
+            owner = remapper.map(owner);
+            changed = changed || this.name != null || !this.owner.equals(owner);
+        } else {
+            name = this.name;
+        }
+
+        MemberInfo next = this.next;
+        if (next != null) {
+            MemberInfo remappedNext = next.remapNestedUsing(remapper);
+            if (remappedNext != null) {
+                changed = true;
+                next = remappedNext;
+            }
+        }
+
+        if (!changed) {
+            return null;
+        }
+
+        return new MemberInfo(name, owner, desc, this.matches, next, this.nextDepth, null);
+    }
+
     /**
      * Parse a MemberInfo from a string
      * 
@@ -905,6 +994,9 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
         Quantifier nextDepth = MemberInfo.DEFAULT_DEPTH;
 
         if (isModern) {
+            if (context != null) {
+                name = context.remap(name);
+            }
             name = name.trim();
 
             Matcher nestedMatcher = MemberInfo.PARSER.matcher(name);
@@ -924,10 +1016,8 @@ public final class MemberInfo implements ITargetSelectorRemappable, ITargetSelec
                 next = MemberInfo.parse(name.substring(arrowPos + 2), context);
                 name = name.substring(0, arrowPos);
             }
-        }
 
-        if (context != null) {
-            name = context.remap(name).trim();
+            name = context.remap(name);
         }
 
         int parenPos = name.indexOf('(');

--- a/src/main/java/org/spongepowered/asm/mixin/refmap/IMixinContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/refmap/IMixinContext.java
@@ -92,4 +92,9 @@ public interface IMixinContext {
      */
     public abstract int getPriority();
 
+    /**
+     * Gets whether this is a compile-time context.
+     */
+    public abstract boolean isCompileTime();
+
 }

--- a/src/main/java/org/spongepowered/asm/mixin/refmap/ReferenceMapper.java
+++ b/src/main/java/org/spongepowered/asm/mixin/refmap/ReferenceMapper.java
@@ -220,7 +220,6 @@ public final class ReferenceMapper implements IReferenceMapper, Serializable {
         if (this.readOnly || reference == null || newReference == null) {
             return null;
         }
-        String conformedReference = reference.replaceAll("\\s", "");
         Map<String, Map<String, String>> mappings = this.mappings;
         if (context != null) {
             mappings = this.data.get(context);
@@ -234,7 +233,7 @@ public final class ReferenceMapper implements IReferenceMapper, Serializable {
             classMappings = new TreeMap<String, String>();
             mappings.put(className, classMappings);
         }
-        return classMappings.put(conformedReference, newReference);
+        return classMappings.put(reference, newReference);
     }
     
     /**

--- a/src/main/java/org/spongepowered/asm/mixin/refmap/RemappingReferenceMapper.java
+++ b/src/main/java/org/spongepowered/asm/mixin/refmap/RemappingReferenceMapper.java
@@ -148,26 +148,8 @@ public final class RemappingReferenceMapper implements IClassReferenceMapper, IR
         if (remappedCached != null) {
             return remappedCached;
         } else {
-            String remapped = origInfoString;
-
-            // To handle propagation, find super/itf-class (for IRemapper)
-            // but pass the requested class in the MemberInfo
-            MemberInfo info = MemberInfo.parse(remapped, null);
-            if (info.getName() == null && info.getDesc() == null) {
-                return info.getOwner() != null ? new MemberInfo(remapper.map(info.getOwner()), Quantifier.DEFAULT).toString() : info.toString();
-            } else if (info.isField()) {
-                remapped = new MemberInfo(
-                        remapper.mapFieldName(info.getOwner(), info.getName(), info.getDesc()),
-                        info.getOwner() == null ? null : remapper.map(info.getOwner()),
-                        info.getDesc() == null ? null : remapper.mapDesc(info.getDesc())
-                ).toString();
-            } else {
-                remapped = new MemberInfo(
-                        remapper.mapMethodName(info.getOwner(), info.getName(), info.getDesc()),
-                        info.getOwner() == null ? null : remapper.map(info.getOwner()),
-                        info.getDesc() == null ? null : remapMethodDescriptor(remapper, info.getDesc())
-                ).toString();
-            }
+            MemberInfo info = MemberInfo.parse(origInfoString, null).remapUsing(this.remapper);
+            String remapped = info != null ? info.toString() : origInfoString;
 
             mappedReferenceCache.put(origInfoString, remapped);
             return remapped;

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTargetContext.java
@@ -1203,6 +1203,11 @@ public class MixinTargetContext extends ClassContext implements IMixinContext {
         return this.mixin.getPriority();
     }
 
+    @Override
+    public boolean isCompileTime() {
+        return false;
+    }
+
     /**
      * Get all interfaces for this mixin
      * 

--- a/src/main/java/org/spongepowered/asm/util/Handles.java
+++ b/src/main/java/org/spongepowered/asm/util/Handles.java
@@ -24,6 +24,11 @@
  */
 package org.spongepowered.asm.util;
 
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
 
@@ -31,6 +36,22 @@ import org.objectweb.asm.Opcodes;
  * Utility class for working with method and field handles
  */
 public final class Handles {
+
+    public static final Handle LMF_HANDLE = new Handle(
+            Opcodes.H_INVOKESTATIC,
+            "java/lang/invoke/LambdaMetafactory",
+            "metafactory",
+            Bytecode.generateDescriptor(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, MethodType.class, MethodHandle.class, MethodType.class),
+            false
+    );
+
+    public static final Handle ALT_LMF_HANDLE = new Handle(
+            Opcodes.H_INVOKESTATIC,
+            "java/lang/invoke/LambdaMetafactory",
+            "altMetafactory",
+            Bytecode.generateDescriptor(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, Object[].class),
+            false
+    );
     
     private static final int[] H_OPCODES = {
         0,                          // invalid

--- a/src/main/java/org/spongepowered/asm/util/NameAndDesc.java
+++ b/src/main/java/org/spongepowered/asm/util/NameAndDesc.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Mixin, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.asm.util;
+
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.Objects;
+
+/**
+ * Represents a method or field, intended for use as a map key
+ */
+public final class NameAndDesc {
+
+    /**
+     * The name of the element
+     */
+    public final String name;
+
+    /**
+     * The bytecode descriptor of the element
+     */
+    public final String desc;
+
+    public NameAndDesc(String name, String desc) {
+        this.name = name;
+        this.desc = desc;
+    }
+
+    public NameAndDesc(MethodNode method) {
+        this(method.name, method.desc);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof NameAndDesc)) {
+            return false;
+        }
+        NameAndDesc that = (NameAndDesc) o;
+        return Objects.equals(name, that.name) && Objects.equals(desc, that.desc);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode() * 31 + desc.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return name + ' ' + desc;
+    }
+}

--- a/src/main/java/org/spongepowered/asm/util/Quantifier.java
+++ b/src/main/java/org/spongepowered/asm/util/Quantifier.java
@@ -184,31 +184,5 @@ public final class Quantifier {
             return Quantifier.NONE;
         }
     }
-    
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof Quantifier) {
-            Quantifier other = (Quantifier)obj;
-            return other.min == this.min && other.max == this.max;
-        }
-        
-        if (obj instanceof Number) {
-            int intValue = ((Number)obj).intValue();
-            return (intValue == this.min) && (intValue == this.max);
-        }
-        
-        return false;
-    }
-    
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
-    @Override
-    public int hashCode() {
-        return 31 * this.min * this.max;
-    }
 
 }

--- a/src/main/java/org/spongepowered/asm/util/Quantifier.java
+++ b/src/main/java/org/spongepowered/asm/util/Quantifier.java
@@ -38,7 +38,7 @@ public final class Quantifier {
     /**
      * Invalid (matches none) 
      */
-    public static Quantifier NONE = new Quantifier(0, 0);
+    public static Quantifier NONE = new Quantifier(0, -2);
     
     /**
      * Single (matches zero or 1)
@@ -74,7 +74,11 @@ public final class Quantifier {
      * Check whether this is a defaulted qualifier
      */
     public boolean isDefault() {
-        return this.min == 0 && this.max < 0;
+        return this.min == 0 && this.max == -1;
+    }
+
+    public boolean isInvalid() {
+        return this.max == -2;
     }
     
     /**
@@ -102,7 +106,7 @@ public final class Quantifier {
      * Get the clamped max value
      */
     public int getClampedMax() {
-        return this.max < 0 ? 1 : Math.max(this.min, this.max);
+        return this.max == -1 ? 1 : Math.max(this.min, this.max);
     }
     
     /* (non-Javadoc)
@@ -116,12 +120,8 @@ public final class Quantifier {
         } else if (this.max < this.min) {
             return "";
         } else {
-            if (this.min == 0) {
-                if (this.max == 1) {
-                    return "";
-                } else if (this.max == Integer.MAX_VALUE) {
-                    return "*";
-                }
+            if (this.min == 0 && this.max == Integer.MAX_VALUE) {
+                return "*";
             }
             if (this.min == 1 && this.max == Integer.MAX_VALUE) {
                 return "+";


### PR DESCRIPTION
> [!WARNING]
> This is ready for review but should not be merged until support is finalised in MCDev and tiny-remapper

This PR adds support for targeting lambdas within methods. A basic example is the following:

```java

@Mixin(SomeTarget.class)
class MyMixin {
    @ModifyConstant(method = "outerMethod ->* *", constant = @Constant(intValue = 5))
    private static int modify5(int five) {
        return five + 1;
    }
}
```

which will modify all `5`s within the *lexical scope* of `outerMethod`, i.e. including inside arbitrarily nested
lambdas (though note this does not include local or anonymous classes).

## Parsing

See [MemberInfo](https://javadoc.io/doc/net.fabricmc/sponge-mixin/latest/org/spongepowered/asm/mixin/injection/struct/MemberInfo.html) for pre-knowledge.

The general format is, in order:

- A normal `MemberInfo`
- `->`
- Optionally a quantifier to specify the nesting depth (defaults to `{1}`)
- An inner `MemberInfo`

This nesting can be repeated multiple times.

Prior to this PR all whitespace is stripped from selectors before they are parsed. This naively allows selectors such as `method = "r e n d e r"`, and prevents whitespace being meaningful. This PR therefore disallows arbitrary whitespace, allowing only whitespace between the elements of a MemberInfo (and at the start/end).

The parsing for nested selectors is whitespace-sensitive, allowing differentiation between
- `outerMethod -> *()V` (any top-level `()V` lambda)
- `outerMethod ->* ()V` (any `()V` lambda or the root if it is also `()V`)

A space is enforced before the arrow and after the arrow (and optional depth quantifier). The depth quantifier, if present, must directly follow the arrow. This ensures selectors remain clearly intelligible by readers.

Note that empty selectors are traditionally valid (e.g. `method = ""` selects the first method). We do not change this, but we do disallow any nesting components being empty, which prevents cursed things like `method = " -> "`. Empty selectors can always be replaced at the top-level by `{0,1}` or at an inner level by `*`

## Root Methods

When a target selector involves nesting (i.e. contains `->`), lambda methods in a class are **not considered** as possible root methods. This is contrary to the default behaviour of `method = "*"` selecting all methods including lambdas.

This is required for intuitive behaviour, so that for example `* -> *` selects only top-level lambdas instead of all lambdas.

If a particular selector wishes, for some reason, to include all lambdas in its root methods, `*` can simply be swapped for `* ->* *`.

## Depth Quantifiers

Depth quantifiers restrict the possible nesting levels at which the inner selector can match. E.g.:

- `outer ->* *` permits any nesting level, including 0, so selects `outer` itself along with all its lambdas
- `outer ->+ *` permits only nesting levels >=1, so selects only `outer`'s lambdas
- `outer ->{2, 4} *` permits nesting levels from 2-4 inclusive
- `* ->{0} *` permits no nesting, i.e. selects all non-lambda methods within the target class

It is possible in obscure cases for lambdas to be reached at multiple depths. In such cases, lambdas are included as long as they appear at some depth which is permitted. E.g. `* ->* * ->{2} *` will match any lambda which is at least doubly nested.

## Nested Owner, Name and Desc

For a top-level method, the selector matches:

- Owner: The class which contains the method
- Name: The exact name of the method
- Desc: The exact descriptor of the method

For a nested method, this is adjusted as follows:

- Owner: The functional interface which the lambda implements
    - This allows matching e.g. `outer ->+ Ljava/lang/Runnable;` to mean any `Runnable` lambda
- Name: The name of the implemented SAM
    - This allows matching e.g. `outer ->+ run` to mean any lambda implementing a `run` method
- Desc: The *specialised desc* of the implemented SAM (does *not* include captures)
    - This allows matching e.g. `outer ->+ Ljava/util/function/Supplier;get()Ljava/lang/String;` to mean any
      `Supplier<String>` lambda

Note that when the depth quantifier permits `0` (e.g. `*`), the outer method is only included if it matches the nested selector. E.g.:

- `outer ->* *` includes `outer` since it matches `*`
- `outer ->* *()V` includes `outer` only if it has the desc `()V`
- `* ->* run()V` matches the top-level method `run()V`, if it exists, along with any lambdas implementing a `run()V` method
- `outer ->* Ljava/lang/Runnable;` never matches the outer method (unless somehow mixing into `Runnable` itself). It is thereby equivalent to `outer ->+ Ljava/lang/Runnable;`, which should be preferred for clarity.

## Nested Quantifiers

Inner selectors can themselves have arbitrary quantifiers, e.g. `outer ->* {2,3}`. Recall that the behaviour of a quantifier is to

- Throw an error if fewer than the minimum number of matches is found
- Ignore further matches once the maximum has been reached

For nested selectors, matches are found depth-first. Consider the following example method:

```java
public void outer() {
    Runnable a = () -> {
        Runnable b = () -> {
            Runnable c = () -> {
            };
        };

        Runnable d = () -> {
        };
    };

    Runnable e = () -> {
    };
}
```

`outer ->+ {3}` matches `a`, `b` and `c`.

Additionally, nested quantifiers are evaluated cumulatively across all parent methods. E.g. `* ->+ {5}` matches the first 5 lambdas in the class (with depth-first ordering as above).

## Remapping

*This section applies to refmaps / the AP only. Future work will be needed in tiny-remapper.*

Selectors are remapped as a whole, i.e. `outer -> inner` gets a standalone refmap entry rather than separate ones for `outer` and `inner`.

Inner method names are remapped differently from root method names. This is necessary because the specified specialised descriptor may not match the method's actual descriptor. Thankfully, when an inner selector is qualified (e.g. `* -> Ljava/lang/Runnable;run`), the owner is enough to uniquely identify the SAM method (since, by definition, there can only be 1). It is remapped therefore to `* -> Ljava/lang/Runnable;`. When a descriptor is included, e.g. `* -> Ljava/util/function/Supplier;get()Ljava/lang/String;`, the descriptor is preserved (and possibly remapped), leaving `* -> Ljava/util/function/Supplier;()Ljava/lang/String;`, which behaves the same. When *no* owner is present, the name is left as-is and cannot be remapped, as is already expected for unqualified references in Mixins.

Recall that injectors allow disabling the AP's remapping via `remap = false`. This option is not granular enough to enable remapping for only specific parts of a nested selector. E.g. when targeting a Minecraft class with `someMethod -> Ljava/lang/Runnable;`, we would want `someMethod` to be remapped, but no mapping would exist for `Runnable`. In light of this, nested components of a selector are **always remapped** and do *not* respect `remap = false`. As such, if mappings for nested parts cannot be found, an error is never raised. This tradeoff means the new feature matches the behaviour users would expect from tiny-remapper, but keeps `remap = true/false` working for root methods so users can benefit from associated errors.

## Backwards Compatibility

Nested selectors have been partially implemented for a long time in upstream, meaning they are parsed but not properly validated or respected. This means that a mod today can write for example `someMethod -> [garbage*{` to mean simply `someMethod`. A mod is unlikely to do this, but the behaviour is preserved out of caution, meaning mods must opt into the new compatibility version to use nested selectors properly.

As for selector parsing, whitespace is still stripped unless a mod opts into the new compatibility version. Nested selectors for old mods are parsed as they were before, but they remain inactive.

## Upstream Divergence

As mentioned, upstream has had this feature partially implemented for a long time, but the implementation in this PR diverges very significantly from what upstream appears to have intended. Most notably:

- Upstream has no notion of depth quantifiers, requiring you to specify the exact nesting level. This is brittle and annoying.
- Upstream matches nested owners against the outer class's owner. This does not gain you any specificity.
- Upstream matches nested descriptors against the lambda's *synthetic* descriptor (including captures). This is brittle.
- Upstream makes no distinction between lambdas and method references, throwing an error if a method reference to a foreign method is found. This is likely a bug.

I believe that all these divergences are for good reason, and do not intend to support upstream's half-baked approach if it ever gets released. I will however attempt to convince them to take ours instead.